### PR TITLE
Add native runtimes and DEV-owned Caddy setup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@bosunski/dev",
@@ -7,6 +8,7 @@
         "@clack/prompts": "^0.10.1",
         "@oclif/core": "^4.3.0",
         "js-yaml": "^4.1.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "latest",
@@ -116,6 +118,8 @@
     "wordwrap": ["wordwrap@1.0.0", "", {}, "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "filelist/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
 

--- a/dev.yml
+++ b/dev.yml
@@ -1,76 +1,39 @@
 name: bosunski/dev
 
 env:
-  PSB_DIR: "${HOME}/.dev/`echo $PWD | md5sum`"
+  BUN_INSTALL: "${HOME}/.bun"
+  PATH: "${HOME}/.bun/bin:${PATH}"
 
 steps:
-  - mysql:
-      databases:
-        - dev_testing
-  - brew:
-      # Required by SPC for building PHP from source
-      - autoconf
-
-  - composer:
-      packages:
-        - phpstan/phpstan
-  - spc:
-      combine:
-        input: builds/dev.phar
-        output: builds/dev
-      php:
-        version: 8.4
-        preset: common
-        extensions:
-          - swoole
-          - ffi
-        sources: {}
-  # - valet:
-  #     php: 8.5
-  #     sites:
-  #       - proxy: http://localhost:8000
-  #         host: psb
-  #       - dev
   - script:
-      desc: Install composer dependencies
-      run: composer install
+      desc: Install Bun
+      met?: test -x "$HOME/.bun/bin/bun"
+      run: curl -fsSL https://bun.com/install | bash
 
   - script:
-      desc: Create output.txt
-      run: echo "Hello World $(date)" > output.txt
+      desc: Install Bun dependencies
+      met?: test -d node_modules
+      run: bun install
 
 commands:
+  test:
+    desc: Run DEV tests
+    run: bun test
   build:
     desc: Build DEV binary
-    signature: "{name?} {subcommand?} {--service}"
-    run: |
-      php dev app:build --build-version=development dev.phar && \
-      php dev spc:combine && chmod +x builds/dev && \
-      rm builds/dev.phar
-  install:
-    desc: Install Dev binary
-    run: |
-      php dev build && \
-      install builds/dev $HOME/.dev/bin/dev
-  php:
-    desc: PHP INI_DIR
-    run: echo $PHP_DIR
-  style:
-    desc: Fix PHP code style
-    run: ./vendor/bin/pint
-  check:
-    desc: PHPStan Analyse
-    run: ./vendor/bin/phpstan analyse --memory-limit=2G
-  test:
-    desc: Run PHP tests
-    run: php vendor/bin/pest
-  coverage:
-    desc: Run PHP tests
-    run: php -d zend_extension=$PWD/dist/xdebug.so vendor/bin/pest --coverage
+    run: bun run build
 
-serve:
-  write: while true; do echo "Hello, DEV! The time is $(date)" >> output.txt; sleep 1; done
-  tail: tail -f output.txt
+  install:
+    desc: Build and install DEV locally
+    run: bun run install:local
+
+  typecheck:
+    desc: Check TypeScript types
+    run: bun run typecheck
+
+  dev:
+    desc: Run DEV from source
+    run: bun run dev
 
 sites:
-  github: https://github.com/phpsandbox/dev
+  github: https://github.com/bosunski/dev

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   "dependencies": {
     "@clack/prompts": "^0.10.1",
     "@oclif/core": "^4.3.0",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.1.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -213,7 +213,7 @@ bash)
     commands=(
         "export $install_env=$quoted_install_dir"
         "export PATH=$bin_env:\$PATH"
-        "eval \$($bin_env/dev env bash)"
+        "eval \"\$($bin_env/dev env bash)\""
     )
 
     bash_configs=(

--- a/src/commands/caddy.ts
+++ b/src/commands/caddy.ts
@@ -1,0 +1,118 @@
+import { Command, Flags } from '@oclif/core'
+import { existsSync, readFileSync } from 'node:fs'
+import { getDevContext } from '../context.js'
+import { CaddyManager } from '../plugins/caddy/caddy-manager.js'
+
+abstract class CaddyCommand extends Command {
+  protected async context(): Promise<Awaited<ReturnType<typeof getDevContext>> & { manager: CaddyManager }> {
+    const context = await getDevContext()
+    return { ...context, manager: new CaddyManager(context.dev.config) }
+  }
+}
+
+export class CaddyStatus extends CaddyCommand {
+  static id = 'caddy:status'
+  static description = 'Show DEV-owned Caddy status'
+  async run(): Promise<void> {
+    await this.parse(CaddyStatus)
+    const { manager } = await this.context()
+    this.log(`Caddy: ${manager.isRunning() ? 'running' : 'stopped'}`)
+    this.log(`Machine bootstrap: ${manager.isBootstrapReady() ? 'ready' : 'required'}`)
+    this.log(`Configuration: ${manager.configIsValid() ? 'valid' : 'missing or invalid'}`)
+    this.log(`Local CA export: ${manager.caIsCurrent() ? 'current' : 'missing or stale'}`)
+    this.log(`Caddyfile: ${manager.caddyfile()}`)
+  }
+}
+
+export class CaddyStart extends CaddyCommand {
+  static id = 'caddy:start'
+  static description = 'Start DEV-owned Caddy'
+  async run(): Promise<void> {
+    await this.parse(CaddyStart)
+    const { dev, manager } = await this.context()
+    if (!await manager.start(dev.runner)) this.exit(1)
+  }
+}
+
+export class CaddyStop extends CaddyCommand {
+  static id = 'caddy:stop'
+  static description = 'Stop DEV-owned Caddy'
+  async run(): Promise<void> {
+    await this.parse(CaddyStop)
+    const { dev, manager } = await this.context()
+    if (!await manager.stop(dev.runner)) this.exit(1)
+  }
+}
+
+export class CaddyReload extends CaddyCommand {
+  static id = 'caddy:reload'
+  static description = 'Regenerate and reload DEV-owned Caddy'
+  async run(): Promise<void> {
+    await this.parse(CaddyReload)
+    const { dev, manager } = await this.context()
+    if (!await manager.reload(dev.runner)) this.exit(1)
+  }
+}
+
+export class CaddyRestart extends CaddyCommand {
+  static id = 'caddy:restart'
+  static description = 'Restart DEV-owned Caddy'
+  async run(): Promise<void> {
+    await this.parse(CaddyRestart)
+    const { dev, manager } = await this.context()
+    if (!await manager.restart(dev.runner)) this.exit(1)
+  }
+}
+
+export class CaddyTrust extends CaddyCommand {
+  static id = 'caddy:trust'
+  static description = 'Trust the DEV-owned Caddy local CA'
+  async run(): Promise<void> {
+    await this.parse(CaddyTrust)
+    const { dev, manager } = await this.context()
+    if (!await manager.trust(dev.runner)) this.exit(1)
+  }
+}
+
+export class CaddyDoctor extends CaddyCommand {
+  static id = 'caddy:doctor'
+  static description = 'Check DEV-owned Caddy configuration and bootstrap state'
+  async run(): Promise<void> {
+    await this.parse(CaddyDoctor)
+    const { manager } = await this.context()
+    const checks = [
+      ['Caddy process', manager.isRunning()],
+      ['Machine bootstrap', manager.isBootstrapReady()],
+      ['Caddy configuration', manager.configIsValid()],
+      ['Local CA export', manager.caIsCurrent()],
+    ] as const
+    for (const [name, passed] of checks) this.log(`${passed ? '✓' : '✗'} ${name}`)
+    if (checks.some(([, passed]) => !passed)) this.exit(1)
+  }
+}
+
+export class CaddyLogs extends CaddyCommand {
+  static id = 'caddy:logs'
+  static description = 'Show DEV-owned Caddy logs'
+  static flags = { follow: Flags.boolean({ char: 'f', description: 'Follow log output' }) }
+  async run(): Promise<void> {
+    const { flags } = await this.parse(CaddyLogs)
+    const { dev, manager } = await this.context()
+    if (!existsSync(manager.logFile())) return
+    if (flags.follow) {
+      if (!await dev.runner.exec(['tail', '-n', '100', '-f', manager.logFile()])) this.exit(1)
+      return
+    }
+    this.log(readFileSync(manager.logFile(), 'utf8').split('\n').slice(-101).join('\n'))
+  }
+}
+
+export class CaddyUnlink extends CaddyCommand {
+  static id = 'caddy:unlink'
+  static description = 'Remove this project from DEV-owned Caddy'
+  async run(): Promise<void> {
+    await this.parse(CaddyUnlink)
+    const { dev, manager } = await this.context()
+    if (!await manager.unlink(dev.runner)) this.exit(1)
+  }
+}

--- a/src/commands/env.ts
+++ b/src/commands/env.ts
@@ -84,24 +84,18 @@ hookbook_add_hook __dev_hook`
 
   private bashHook(self: string): string {
     return `__dev_hook() {
-  local flags; flags=(--shellpid "$$")
-  eval "$("${self}" hook "\${flags[@]}")"
+  eval "$("${self}" hook)"
 }
 
-${HOOKBOOK}
-
 __dev_force_run=1
-hookbook_add_hook __dev_hook`
+if [[ ";\${PROMPT_COMMAND:-};" != *";__dev_hook;"* ]]; then
+  PROMPT_COMMAND="__dev_hook\${PROMPT_COMMAND:+; \${PROMPT_COMMAND}}"
+fi`
   }
 
   private fishHook(self: string): string {
     return `function __dev_hook --on-event fish_prompt --on-variable PWD
-  set -l flags --fish
-  if [ -n "$__dev_force_run" ];
-    set -a flags --force
-    set -eg __dev_force_run
-  end
-  "${self}" hook $flags | source 2>/dev/null
+  "${self}" hook | source 2>/dev/null
 end
 
 set -g __dev_force_run 1`

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -14,3 +14,14 @@ export { default as Inspire } from './inspire.js'
 export { default as SpcInstall } from './spc/install.js'
 export { default as ProjectDisable } from './project/disable.js'
 export { default as ProjectEnable } from './project/enable.js'
+export {
+  CaddyDoctor,
+  CaddyLogs,
+  CaddyReload,
+  CaddyRestart,
+  CaddyStart,
+  CaddyStatus,
+  CaddyStop,
+  CaddyTrust,
+  CaddyUnlink,
+} from './caddy.js'

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -2,6 +2,7 @@ import { Command, Args, Flags } from '@oclif/core'
 import * as clack from '@clack/prompts'
 import { getDevContext } from '../context.js'
 import { UserException } from '../exceptions.js'
+import { commandWorkingDirectory } from '../config/command.js'
 
 export default class Run extends Command {
   static id = 'run'
@@ -50,7 +51,7 @@ export default class Run extends Command {
       throw new UserException(`Command ${name} not found. Are you sure you have it configured?`)
     }
 
-    const proc = await dev.runner.spawn(command.run, dev.config.cwd())
+    const proc = await dev.runner.spawn(command.run, commandWorkingDirectory(dev.config, command))
     const code = await proc.exited
     if (code !== 0) this.exit(code)
   }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -1,5 +1,6 @@
 import { Command, Args, Flags } from '@oclif/core'
 import * as clack from '@clack/prompts'
+import { z } from 'zod'
 import { ServeManager } from '../process/serve-manager.js'
 import { getDevContext } from '../context.js'
 
@@ -22,13 +23,13 @@ export default class Serve extends Command {
     const manager = new ServeManager(dev)
 
     if (argv.length > 0 || flags.all) {
-      await manager.run(flags.all ? undefined : (argv as string[]))
+      if (!await manager.run(flags.all ? undefined : z.array(z.string()).parse(argv))) this.exit(1)
       return
     }
 
     const availableGroups = manager.getGroups(dev)
     if (availableGroups.length === 0) {
-      await manager.run()
+      if (!await manager.run()) this.exit(1)
       return
     }
 
@@ -40,7 +41,8 @@ export default class Serve extends Command {
 
     if (clack.isCancel(selected)) process.exit(0)
 
-    const groups = (selected as string[]).length > 0 ? (selected as string[]) : undefined
-    await manager.run(groups)
+    const selectedGroups = z.array(z.string()).parse(selected)
+    const groups = selectedGroups.length > 0 ? selectedGroups : undefined
+    if (!await manager.run(groups)) this.exit(1)
   }
 }

--- a/src/config/command.ts
+++ b/src/config/command.ts
@@ -1,0 +1,6 @@
+import type { Config } from './config.js'
+import type { RawCommand } from '../types/config.js'
+
+export function commandWorkingDirectory(config: Config, command: RawCommand): string {
+  return command.cwd ? config.cwd(command.cwd) : config.cwd()
+}

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -4,14 +4,22 @@ import yaml from 'js-yaml'
 import { Env } from './env.js'
 import { UpConfig } from './up-config.js'
 import { ProjectDefinition } from './project-definition.js'
-import type { RawConfig, RawCommand, RawServe, RawServeProcess } from '../types/config.js'
+import type { RawConfig, RawCommand, RawRuntime, RawServe, RawServeProcess } from '../types/config.js'
 import { UserException } from '../exceptions.js'
+import { rawConfigSchema } from '../types/config.js'
+import { z } from 'zod'
 
 export type DevSettings = {
   locks: Record<string, string>
   disabled: string[]
   env: Record<string, string>
 }
+
+const devSettingsSchema = z.object({
+  locks: z.record(z.string(), z.string()).optional(),
+  disabled: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+})
 
 export class Config {
   static readonly DevDir = '.dev'
@@ -47,7 +55,7 @@ export class Config {
     this.readSettings()
     this._up = new UpConfig(raw.steps ?? raw.up ?? [])
     this._env = new Env(raw.env ?? {}, Object.fromEntries(
-      Object.entries(process.env).filter(([, v]) => v !== undefined) as [string, string][]
+      Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
     ))
     this._uname = process.platform === 'darwin' ? 'Darwin' : process.platform === 'linux' ? 'Linux' : 'Windows'
   }
@@ -57,8 +65,12 @@ export class Config {
     if (existsSync(jsonPath)) {
       try {
         const content = readFileSync(jsonPath, 'utf8')
-        const parsed = JSON.parse(content) as Partial<DevSettings>
-        this.settings = { ...this.settings, ...parsed }
+        const parsed = devSettingsSchema.parse(JSON.parse(content))
+        this.settings = {
+          locks: parsed.locks ?? this.settings.locks,
+          disabled: parsed.disabled ?? this.settings.disabled,
+          env: parsed.env ?? this.settings.env,
+        }
       } catch {
         throw new UserException(`Failed to parse ${jsonPath}. Please check the file for syntax errors.`)
       }
@@ -91,6 +103,10 @@ export class Config {
 
   sites(): Record<string, string> {
     return this.raw.sites ?? {}
+  }
+
+  runtimes(): Record<string, RawRuntime> {
+    return this.raw.runtimes ?? {}
   }
 
   commands(): Record<string, RawCommand> {
@@ -176,7 +192,7 @@ export class Config {
   private static loadYaml(fullPath: string): RawConfig {
     if (!existsSync(fullPath)) return {}
     try {
-      return (yaml.load(readFileSync(fullPath, 'utf8')) as RawConfig) ?? {}
+      return rawConfigSchema.parse(yaml.load(readFileSync(fullPath, 'utf8')) ?? {})
     } catch (e) {
       throw new UserException(`Failed to parse ${fullPath}: ${String(e)}`)
     }
@@ -196,6 +212,9 @@ export class Config {
 
     const sites = { ...base.sites, ...local.sites }
     if (Object.keys(sites).length > 0) merged.sites = sites
+
+    const runtimes = { ...base.runtimes, ...local.runtimes }
+    if (Object.keys(runtimes).length > 0) merged.runtimes = runtimes
 
     const mergedServe = Config.mergeServe(base.serve, local.serve)
     if (mergedServe !== undefined) merged.serve = mergedServe

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -26,7 +26,10 @@ export class Env {
     for (const [key, rawValue] of Object.entries(this._raw)) {
       const value = Value.from(rawValue)
 
-      if (value.shouldPrompt() && key in prompted) {
+      const supplied = this.substitutions[key]
+      if (value.shouldPrompt() && supplied) {
+        this.env.set(key, supplied)
+      } else if (value.shouldPrompt() && key in prompted) {
         const resolved = prompted[key]!
         this.env.set(key, resolved)
         this.prompted[key] = resolved

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,7 @@ import { ValetPlugin } from './plugins/valet/valet-plugin.js'
 import { SpcPlugin } from './plugins/spc/spc-plugin.js'
 import { CaddyPlugin } from './plugins/caddy/caddy-plugin.js'
 import { DopplerPlugin } from './plugins/doppler/doppler-plugin.js'
+import { PhpRuntimePlugin } from './plugins/php-runtime/php-runtime-plugin.js'
 import type { PluginInterface } from './types/plugin.js'
 
 const DEFAULT_PLUGINS: Array<new () => PluginInterface> = [
@@ -22,6 +23,7 @@ const DEFAULT_PLUGINS: Array<new () => PluginInterface> = [
   SpcPlugin,
   CaddyPlugin,
   DopplerPlugin,
+  PhpRuntimePlugin,
 ]
 
 let _dev: Dev | null = null

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { Config } from './config/config.js'
 import type { Runner } from './execution/runner.js'
 import type { IOInterface } from './types/io.js'
@@ -67,13 +67,24 @@ export class Dev {
     return all.filter((p, i) => all.lastIndexOf(p) === i)
   }
 
+  effectivePath(base = process.env['PATH'] ?? ''): string {
+    return this.paths().reduce((path, entry) => `${entry}:${path}`, base)
+  }
+
   async updateEnvironment(): Promise<boolean> {
     if (!this.initShadowenvDir()) return false
     await this.primeEnvCache()
     if (this.createDefaultLispFile() && this.createGitIgnoreFile()) {
-      return this.runner.withoutShadowEnv().exec([this.config.brewPath('bin/shadowenv'), 'trust'])
+      return this.runner.withoutShadowEnv().exec([this.runner.shadowenvBin(), 'trust'])
     }
     return false
+  }
+
+  async environmentIsCurrent(): Promise<boolean> {
+    const file = this.config.cwd(this.shadowenvPath('000_default.lisp'))
+    if (!existsSync(file)) return false
+    await this.primeEnvCache()
+    return readFileSync(file, 'utf8') === this.defaultLispContent()
   }
 
   private initShadowenvDir(): boolean {

--- a/src/execution/privilege.ts
+++ b/src/execution/privilege.ts
@@ -1,0 +1,7 @@
+export type ElevationTool = 'pkexec' | 'sudo'
+
+export function elevationTool(): ElevationTool {
+  const configured = process.env['DEV_ELEVATION_TOOL']
+  if (configured === 'pkexec' || configured === 'sudo') return configured
+  return process.stdin.isTTY ? 'sudo' : 'pkexec'
+}

--- a/src/execution/runner.ts
+++ b/src/execution/runner.ts
@@ -170,6 +170,9 @@ export class Runner {
     }
 
     this.checkShadowEnv()
+    if (!this.usingShadowEnv) {
+      return typeof command === 'string' ? ['sh', '-c', command] : command
+    }
 
     if (Array.isArray(command) && !this.requiresShell(command)) {
       return [this.shadowenvBin(), 'exec', '--', ...command]
@@ -209,7 +212,7 @@ export class Runner {
       const result = Bun.spawnSync(
         [shell.bin, '-c', `(source ${shell.profile} && command -v __shadowenv_hook) >/dev/null 2>&1`],
       )
-      const hookInstalled = result.exitCode === 0
+      const hookInstalled = result.exitCode === 0 && existsSync(this.shadowenvBin())
       this._shadowEnvChecked = hookInstalled
       this.usingShadowEnv = hookInstalled
 
@@ -223,7 +226,7 @@ export class Runner {
   }
 
   shadowenvBin(): string {
-    return this.config.brewPath('bin/shadowenv')
+    return Bun.which('shadowenv') ?? this.config.globalBinPath('shadowenv')
   }
 
   hasCommand(command: string): boolean {

--- a/src/main.ts
+++ b/src/main.ts
@@ -115,7 +115,8 @@ async function runConfigCommand(name: string, args: string[]): Promise<void> {
     }
   }
 
-  const proc = await dev.runner.spawn(cmdRun, dev.config.cwd())
+  const { commandWorkingDirectory } = await import('./config/command.js')
+  const proc = await dev.runner.spawn(cmdRun, commandWorkingDirectory(dev.config, command))
   const code = await proc.exited
   process.exit(code)
 }

--- a/src/plugin/plugin-args.ts
+++ b/src/plugin/plugin-args.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod'
+import { Dev } from '../dev.js'
+
+const pluginArgsSchema = z.object({ dev: z.instanceof(Dev) })
+
+export function pluginDev(args: Record<string, unknown>): Dev {
+  return pluginArgsSchema.parse(args).dev
+}

--- a/src/plugins/caddy/caddy-command-provider.ts
+++ b/src/plugins/caddy/caddy-command-provider.ts
@@ -1,29 +1,13 @@
 import type { Command } from '@oclif/core'
 import type { CommandProvider } from '../../types/capability.js'
 import type { RawCommand } from '../../types/config.js'
-import type { Dev } from '../../dev.js'
 
 export class CaddyCommandProvider implements CommandProvider {
-  private readonly dev: Dev
-
-  constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
-  }
-
   getCommands(): Command.Class[] {
     return []
   }
 
   getConfigCommands(): Record<string, RawCommand> {
-    const rawSteps = this.dev.config.raw_().steps ?? this.dev.config.raw_().up ?? []
-    const hasCaddy = rawSteps.some(s => s && typeof s === 'object' && 'caddy' in s)
-    if (!hasCaddy) return {}
-
-    return {
-      'caddy:restart': {
-        desc: 'Restart Caddy',
-        run: 'caddy stop; caddy start',
-      },
-    }
+    return {}
   }
 }

--- a/src/plugins/caddy/caddy-config-provider.ts
+++ b/src/plugins/caddy/caddy-config-provider.ts
@@ -5,12 +5,15 @@ import { CaddyStepResolver } from './caddy-step-resolver.js'
 import { InstallCaddyStep } from './steps/install-caddy-step.js'
 import { PrepareCaddyStep } from './steps/prepare-caddy-step.js'
 import { PostUpStep } from './steps/post-up-step.js'
+import { BootstrapCaddyStep } from './steps/bootstrap-caddy-step.js'
+import { pluginDev } from '../../plugin/plugin-args.js'
+import { rawCaddyConfigSchema } from './caddy-step-resolver.js'
 
 export class CaddyConfigProvider implements ConfigProvider {
   private readonly dev: Dev
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
+    this.dev = pluginDev(args)
   }
 
   steps(): Step[] {
@@ -19,14 +22,13 @@ export class CaddyConfigProvider implements ConfigProvider {
     let hasCaddy = false
 
     for (const rawStep of rawSteps) {
-      if (!rawStep || typeof rawStep !== 'object') continue
-      const c = (rawStep as Record<string, unknown>)['caddy'] as Record<string, unknown> | undefined
-      if (!c) continue
+      if (!('caddy' in rawStep)) continue
+      const c = rawCaddyConfigSchema.parse(rawStep['caddy'])
       hasCaddy = true
-      const rawSites = c['sites']
+      const rawSites = c.sites
       if (Array.isArray(rawSites)) {
         for (const site of rawSites) {
-          const host = typeof site === 'string' ? site : (site as Record<string, string>)['host']
+          const host = typeof site === 'string' ? site : site.host
           if (host) sites.push(host)
         }
       }
@@ -36,6 +38,7 @@ export class CaddyConfigProvider implements ConfigProvider {
 
     return [
       new InstallCaddyStep(),
+      new BootstrapCaddyStep(),
       new PrepareCaddyStep(),
       new PostUpStep(sites),
     ]

--- a/src/plugins/caddy/caddy-env-provider.ts
+++ b/src/plugins/caddy/caddy-env-provider.ts
@@ -1,16 +1,26 @@
 import type { EnvProvider } from '../../types/capability.js'
 import type { Dev } from '../../dev.js'
+import { caddyProjectSitesDir } from './caddy-layout.js'
+import { pluginDev } from '../../plugin/plugin-args.js'
+import { hasCaddyConfig } from './caddy-step-resolver.js'
 
 export class CaddyEnvProvider implements EnvProvider {
   private readonly dev: Dev
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
+    this.dev = pluginDev(args)
   }
 
   envs(): Record<string, string> {
+    const steps = this.dev.config.raw_().steps ?? this.dev.config.raw_().up ?? []
+    if (!steps.some(hasCaddyConfig)) return {}
+
     return {
-      CADDY_SITE_PATH: this.dev.config.globalPath('caddy/sites'),
+      CADDY_SITE_PATH: caddyProjectSitesDir(
+        this.dev.config.globalPath('caddy'),
+        this.dev.config.cwd(),
+      ),
+      LOCAL_DEV_CA_CERT_PATH: this.dev.config.globalPath('caddy/ca/root.crt'),
     }
   }
 }

--- a/src/plugins/caddy/caddy-layout.ts
+++ b/src/plugins/caddy/caddy-layout.ts
@@ -1,0 +1,18 @@
+import { createHash } from 'node:crypto'
+import { basename, join } from 'node:path'
+
+export function caddyProjectId(cwd: string): string {
+  const label = basename(cwd).replace(/[^a-zA-Z0-9._-]+/g, '-').replace(/^-+|-+$/g, '') || 'project'
+  const hash = createHash('sha256').update(cwd).digest('hex').slice(0, 12)
+  return `${label}-${hash}`
+}
+
+export function caddyProjectSitesDir(globalCaddyDir: string, cwd: string): string {
+  return join(globalCaddyDir, 'projects', caddyProjectId(cwd), 'sites')
+}
+
+export function caddySiteFilename(host: string): string {
+  const label = host.replace(/[^a-zA-Z0-9._*-]+/g, '-').replace(/^-+|-+$/g, '') || 'site'
+  const hash = createHash('sha256').update(host).digest('hex').slice(0, 12)
+  return `${label}-${hash}.conf`
+}

--- a/src/plugins/caddy/caddy-manager.ts
+++ b/src/plugins/caddy/caddy-manager.ts
@@ -1,0 +1,191 @@
+import { createHash } from 'node:crypto'
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { dirname, join, relative } from 'node:path'
+import type { Config } from '../../config/config.js'
+import type { Runner } from '../../execution/runner.js'
+import { UserException } from '../../exceptions.js'
+import { caddyProjectSitesDir } from './caddy-layout.js'
+import { CaddyRuntime } from './caddy-runtime.js'
+
+export class CaddyManager {
+  private readonly runtime = new CaddyRuntime()
+
+  constructor(private readonly config: Config) {}
+
+  caddyfile(): string { return this.config.globalPath('caddy/Caddyfile') }
+  logFile(): string { return this.config.globalPath('caddy/logs/caddy.log') }
+  isRunning(): boolean { return this.bootstrapReady() && this.runtime.isRunning() }
+  isBootstrapReady(): boolean { return this.bootstrapReady() }
+  caIsCurrent(): boolean {
+    const source = this.runtime.caCertificateSource()
+    const target = this.config.globalPath('caddy/ca/root.crt')
+    return existsSync(source) && existsSync(target)
+      && readFileSync(source).equals(readFileSync(target))
+  }
+
+  configIsValid(): boolean {
+    return existsSync(this.caddyfile())
+      && Bun.spawnSync(this.runtime.validateCommand(this.caddyfile()), {
+        stdout: 'ignore', stderr: 'ignore',
+      }).exitCode === 0
+  }
+
+  isDeployed(): boolean {
+    const content = this.content()
+    const hashFile = this.config.globalPath('caddy/.deployed-hash')
+    return existsSync(hashFile)
+      && readFileSync(hashFile, 'utf8').trim() === this.hash(content)
+      && this.caIsCurrent()
+      && this.isRunning()
+  }
+
+  async deploy(runner: Runner): Promise<boolean> {
+    this.requireBootstrap()
+    const content = this.content()
+    mkdirSync(dirname(this.caddyfile()), { recursive: true })
+    mkdirSync(dirname(this.logFile()), { recursive: true })
+    writeFileSync(this.caddyfile(), content)
+    if (!await runner.exec(this.runtime.validateCommand(this.caddyfile()))) return false
+
+    if (this.isRunning()) {
+      if (!await runner.exec(this.runtime.reloadCommand(this.caddyfile()))) return false
+    } else {
+      this.writeUserService()
+      if (!await this.startUserService(runner)) return false
+    }
+    if (!await this.ensureTrusted(runner)) return false
+
+    writeFileSync(this.config.globalPath('caddy/.deployed-hash'), this.hash(content) + '\n')
+    return true
+  }
+
+  async start(runner: Runner): Promise<boolean> {
+    this.requireBootstrap()
+    if (this.isRunning()) return true
+    mkdirSync(dirname(this.caddyfile()), { recursive: true })
+    mkdirSync(dirname(this.logFile()), { recursive: true })
+    if (!existsSync(this.caddyfile())) writeFileSync(this.caddyfile(), this.content())
+    if (!await runner.exec(this.runtime.validateCommand(this.caddyfile()))) return false
+    this.writeUserService()
+    return this.startUserService(runner)
+  }
+
+  async reload(runner: Runner): Promise<boolean> {
+    return this.isRunning() ? this.deploy(runner) : this.start(runner)
+  }
+
+  async restart(runner: Runner): Promise<boolean> {
+    this.requireBootstrap()
+    this.writeUserService()
+    if (this.runtime.platform === 'linux') {
+      if (!this.isRunning()) return this.startUserService(runner)
+      if (!await runner.exec(['systemctl', '--user', 'daemon-reload'])) return false
+      return runner.exec(this.runtime.linuxUserRestartCommand())
+    }
+    if (this.isRunning() && !await this.stop(runner)) return false
+    return this.startUserService(runner)
+  }
+
+  async stop(runner: Runner): Promise<boolean> {
+    if (!this.isRunning()) return true
+    return this.runtime.platform === 'darwin'
+      ? runner.exec(this.runtime.darwinUserStopCommand())
+      : runner.exec(this.runtime.linuxUserStopCommand())
+  }
+
+  async trust(runner: Runner): Promise<boolean> {
+    if (!this.isRunning() && !await this.start(runner)) return false
+    return this.ensureTrusted(runner, true)
+  }
+
+  async unlink(runner: Runner): Promise<boolean> {
+    this.requireBootstrap()
+    const sitesDir = caddyProjectSitesDir(this.config.globalPath('caddy'), this.config.cwd())
+    const projectsDir = this.config.globalPath('caddy/projects')
+    const child = relative(projectsDir, sitesDir)
+    if (child.startsWith('..') || child === '' || !sitesDir.endsWith('/sites')) {
+      throw new UserException(`Refusing to unlink unexpected Caddy path: ${sitesDir}`)
+    }
+    if (existsSync(sitesDir)) rmSync(sitesDir, { recursive: true })
+    return this.deploy(runner)
+  }
+
+  content(): string {
+    const projectsDir = this.config.globalPath('caddy/projects')
+    const files: string[] = []
+    if (existsSync(projectsDir)) {
+      for (const project of readdirSync(projectsDir).sort()) {
+        const sitesDir = join(projectsDir, project, 'sites')
+        if (!existsSync(sitesDir)) continue
+        for (const file of readdirSync(sitesDir).filter(candidate => candidate.endsWith('.conf')).sort()) {
+          files.push(join(sitesDir, file))
+        }
+      }
+    }
+
+    const options = [
+      '{',
+      `\tadmin 127.0.0.1:${this.runtime.adminPort()}`,
+      '\tskip_install_trust',
+      ...((this.runtime.httpPort() !== 80 || this.runtime.httpsPort() !== 443)
+        ? [`\thttp_port ${this.runtime.httpPort()}`, `\thttps_port ${this.runtime.httpsPort()}`]
+        : []),
+      '\tlog default {',
+      `\t\toutput file ${JSON.stringify(this.logFile())}`,
+      '\t}',
+      '}',
+    ].join('\n')
+    const raw = `${options}\n${files.map(file => readFileSync(file, 'utf8')).join('\n')}`
+    const formatted = Bun.spawnSync([this.runtime.binary, 'fmt', '-'], {
+      stdin: Buffer.from(raw), stdout: 'pipe', stderr: 'pipe',
+    })
+    return formatted.exitCode === 0 ? formatted.stdout.toString() : raw
+  }
+
+  private async ensureTrusted(runner: Runner, force = false): Promise<boolean> {
+    if (!force && this.caIsCurrent()) return true
+    if (!await runner.exec(this.runtime.trustCommand())) return false
+    const source = this.runtime.caCertificateSource()
+    if (!existsSync(source)) return false
+    return runner.exec(['install', '-D', '-m', '0644', source, this.config.globalPath('caddy/ca/root.crt')])
+  }
+
+  private writeUserService(): void {
+    const serviceFile = this.runtime.userServiceFile()
+    mkdirSync(dirname(serviceFile), { recursive: true })
+    writeFileSync(serviceFile, this.runtime.userServiceContent(this.caddyfile(), this.logFile()))
+  }
+
+  private async startUserService(runner: Runner): Promise<boolean> {
+    if (this.runtime.platform === 'linux') {
+      for (const command of this.runtime.linuxUserStartCommands()) {
+        if (!await runner.exec(command)) return false
+      }
+      return true
+    }
+    const serviceFile = this.runtime.userServiceFile()
+    if (await runner.exec(this.runtime.darwinUserBootstrapCommand(serviceFile))) return true
+    return runner.exec(this.runtime.darwinUserKickstartCommand())
+  }
+
+  private bootstrapReady(): boolean {
+    if (this.runtime.platform === 'darwin') {
+      return existsSync(this.config.globalPath('caddy/.pf-configured'))
+    }
+    if (!this.runtime.usesPrivilegedPorts()) return true
+    if (this.runtime.platform === 'linux') {
+      return this.runtime.hasLowPortAccess() && !this.runtime.systemServiceActive()
+    }
+    return false
+  }
+
+  private requireBootstrap(): void {
+    if (!this.bootstrapReady()) {
+      throw new UserException('DEV-owned Caddy requires its one-time machine bootstrap. Run `dev up` first.')
+    }
+  }
+
+  private hash(content: string): string {
+    return createHash('sha256').update(content).digest('hex')
+  }
+}

--- a/src/plugins/caddy/caddy-runtime.ts
+++ b/src/plugins/caddy/caddy-runtime.ts
@@ -1,0 +1,129 @@
+import { join } from 'node:path'
+import { elevationTool, type ElevationTool } from '../../execution/privilege.js'
+
+export class CaddyRuntime {
+  constructor(
+    public readonly platform = process.platform,
+    public readonly binary = Bun.which('caddy') ?? 'caddy',
+    private readonly elevation: ElevationTool = elevationTool(),
+    private readonly env: Record<string, string | undefined> = process.env,
+  ) {}
+
+  httpPort(): number { return this.port('DEV_CADDY_HTTP_PORT', this.platform === 'darwin' ? 8080 : 80) }
+  httpsPort(): number { return this.port('DEV_CADDY_HTTPS_PORT', this.platform === 'darwin' ? 8443 : 443) }
+  adminPort(): number { return this.port('DEV_CADDY_ADMIN_PORT', 2019) }
+  usesPrivilegedPorts(): boolean { return this.httpPort() < 1024 || this.httpsPort() < 1024 }
+
+  reloadCommand(config: string): string[] {
+    return [this.binary, 'reload', '--config', config, '--address', `127.0.0.1:${this.adminPort()}`, '--force']
+  }
+  validateCommand(config: string): string[] { return [this.binary, 'validate', '--config', config] }
+
+  trustCommand(): string[] {
+    return [this.binary, 'trust', '--address', `127.0.0.1:${this.adminPort()}`]
+  }
+
+  isRunning(): boolean {
+    return Bun.spawnSync(['curl', '-fsS', `http://127.0.0.1:${this.adminPort()}/config/`], {
+      stdout: 'ignore', stderr: 'ignore',
+    }).exitCode === 0
+  }
+
+  systemServiceActive(): boolean {
+    return this.platform === 'linux'
+      && Bun.spawnSync(['systemctl', 'is-active', '--quiet', 'caddy'], {
+        stdout: 'ignore', stderr: 'ignore',
+      }).exitCode === 0
+  }
+
+  hasLowPortAccess(): boolean {
+    if (!this.usesPrivilegedPorts()) return true
+    if (this.platform !== 'linux') return this.platform === 'darwin'
+    const result = Bun.spawnSync(['getcap', this.binary], { stdout: 'pipe', stderr: 'ignore' })
+    return result.exitCode === 0 && result.stdout.toString().includes('cap_net_bind_service=ep')
+  }
+
+  linuxBootstrapCommands(): string[][] {
+    return [
+      [this.elevation, 'systemctl', 'disable', '--now', 'caddy'],
+      [this.elevation, 'setcap', 'cap_net_bind_service=+ep', this.binary],
+    ]
+  }
+
+  darwinBootstrapCommands(rulesFile: string): string[][] {
+    return [
+      [this.elevation, 'pfctl', '-a', 'com.apple/dev.caddy', '-f', rulesFile],
+      [this.elevation, 'pfctl', '-E'],
+    ]
+  }
+
+  userServiceFile(home = process.env['HOME'] ?? ''): string {
+    return this.platform === 'darwin'
+      ? join(home, 'Library/LaunchAgents/com.bosunski.dev.caddy.plist')
+      : join(home, '.config/systemd/user/dev-caddy.service')
+  }
+
+  userServiceContent(config: string, logFile: string): string {
+    if (this.platform === 'darwin') {
+      return `<?xml version="1.0" encoding="UTF-8"?>\n`
+        + `<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">\n`
+        + `<plist version="1.0"><dict>\n`
+        + `<key>Label</key><string>com.bosunski.dev.caddy</string>\n`
+        + `<key>ProgramArguments</key><array><string>${this.xml(this.binary)}</string><string>run</string>`
+        + `<string>--config</string><string>${this.xml(config)}</string></array>\n`
+        + `<key>RunAtLoad</key><true/><key>KeepAlive</key><true/>\n`
+        + `<key>StandardOutPath</key><string>${this.xml(logFile)}</string>`
+        + `<key>StandardErrorPath</key><string>${this.xml(logFile)}</string>\n`
+        + `</dict></plist>\n`
+    }
+    return `[Unit]\nDescription=DEV-owned Caddy\nAfter=network-online.target\n\n`
+      + `[Service]\nExecStart=${this.systemd(this.binary)} run --config ${this.systemd(config)}\n`
+      + `ExecReload=${this.systemd(this.binary)} reload --config ${this.systemd(config)}`
+      + ` --address 127.0.0.1:${this.adminPort()} --force\n`
+      + `Restart=on-failure\nRestartSec=1\n\n`
+      + `[Install]\nWantedBy=default.target\n`
+  }
+
+  linuxUserStartCommands(): string[][] {
+    return [
+      ['systemctl', '--user', 'daemon-reload'],
+      ['systemctl', '--user', 'enable', '--now', 'dev-caddy.service'],
+    ]
+  }
+
+  linuxUserStopCommand(): string[] { return ['systemctl', '--user', 'stop', 'dev-caddy.service'] }
+  linuxUserRestartCommand(): string[] { return ['systemctl', '--user', 'restart', 'dev-caddy.service'] }
+
+  darwinUserBootstrapCommand(serviceFile: string, uid = process.getuid?.() ?? 0): string[] {
+    return ['launchctl', 'bootstrap', `gui/${uid}`, serviceFile]
+  }
+
+  darwinUserKickstartCommand(uid = process.getuid?.() ?? 0): string[] {
+    return ['launchctl', 'kickstart', '-k', `gui/${uid}/com.bosunski.dev.caddy`]
+  }
+
+  darwinUserStopCommand(uid = process.getuid?.() ?? 0): string[] {
+    return ['launchctl', 'bootout', `gui/${uid}/com.bosunski.dev.caddy`]
+  }
+
+  caCertificateSource(
+    home = process.env['HOME'] ?? '',
+    dataHome = process.env['XDG_DATA_HOME'] ?? join(home, '.local/share'),
+  ): string {
+    if (this.platform === 'darwin') return join(home, 'Library/Application Support/Caddy/pki/authorities/local/root.crt')
+    return join(dataHome, 'caddy/pki/authorities/local/root.crt')
+  }
+
+  private port(name: string, fallback: number): number {
+    const parsed = Number(this.env[name])
+    return Number.isInteger(parsed) && parsed > 0 && parsed <= 65535 ? parsed : fallback
+  }
+
+  private xml(value: string): string {
+    return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+  }
+
+  private systemd(value: string): string {
+    return `"${value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')}"`
+  }
+}

--- a/src/plugins/caddy/caddy-step-resolver.ts
+++ b/src/plugins/caddy/caddy-step-resolver.ts
@@ -1,18 +1,66 @@
 import type { StepResolver, Step } from '../../types/step.js'
 import type { Dev } from '../../dev.js'
 import { CaddyStep } from './steps/caddy-step.js'
+import { caddyProjectSitesDir } from './caddy-layout.js'
+import { PhpRuntime } from '../php-runtime/php-runtime.js'
+import { z } from 'zod'
+import type { RawStep } from '../../types/config.js'
+import { CaddyManager } from './caddy-manager.js'
 
-export type RawCaddySite = string | { host: string; proxy?: string; secure?: boolean }
+const headersSchema = z.record(z.string(), z.string())
+const caddyRouteSchema = z.object({
+  path: z.string(),
+  proxy: z.string().optional(),
+  file_server: z.boolean().optional(),
+  strip_prefix: z.string().optional(),
+  response_headers: headersSchema.optional(),
+  request_headers: headersSchema.optional(),
+  flush_interval: z.string().optional(),
+}).refine(route => route.proxy || route.file_server, { message: 'A Caddy route requires proxy or file_server.' })
+const caddySiteSchema = z.union([z.string(), z.object({
+  host: z.string(),
+  proxy: z.string().optional(),
+  root: z.string().optional(),
+  php_fastcgi: z.string().optional(),
+  runtime: z.string().optional(),
+  secure: z.boolean().optional(),
+  tls: z.enum(['automatic', 'internal']).optional(),
+  max_request_body: z.string().optional(),
+  response_headers: headersSchema.optional(),
+  request_headers: headersSchema.optional(),
+  flush_interval: z.string().optional(),
+  routes: z.array(caddyRouteSchema).optional(),
+}).refine(site => !(site.runtime && site.php_fastcgi), {
+  message: 'A Caddy site cannot define both runtime and php_fastcgi.',
+})])
+export const rawCaddyConfigSchema = z.object({ sites: z.array(caddySiteSchema).optional() })
+export type RawCaddyRoute = z.infer<typeof caddyRouteSchema>
+export type RawCaddySite = z.infer<typeof caddySiteSchema>
+export type RawCaddyConfig = z.infer<typeof rawCaddyConfigSchema>
 
-export type RawCaddyConfig = {
-  sites?: RawCaddySite[]
+export function hasCaddyConfig(step: RawStep): boolean {
+  if (!('caddy' in step)) return false
+  rawCaddyConfigSchema.parse(step['caddy'])
+  return true
 }
 
 export class CaddyStepResolver implements StepResolver {
   constructor(private readonly dev: Dev) {}
 
   resolve(args: unknown): Step {
-    const sitesDir = this.dev.config.globalPath('caddy/sites')
-    return new CaddyStep(args as RawCaddyConfig, sitesDir)
+    const sitesDir = caddyProjectSitesDir(
+      this.dev.config.globalPath('caddy'),
+      this.dev.config.cwd(),
+    )
+    const config = rawCaddyConfigSchema.parse(args)
+    const sites = (config.sites ?? []).map(site => {
+      if (typeof site === 'string' || !site.runtime) return site
+      return { ...site, php_fastcgi: PhpRuntime.endpoint(this.dev.config, site.runtime) }
+    })
+    return new CaddyStep(
+      { ...config, sites },
+      sitesDir,
+      runner => new CaddyManager(runner.config).deploy(runner),
+    )
   }
 }

--- a/src/plugins/caddy/steps/bootstrap-caddy-step.ts
+++ b/src/plugins/caddy/steps/bootstrap-caddy-step.ts
@@ -1,0 +1,43 @@
+import { existsSync, writeFileSync } from 'node:fs'
+import type { Runner } from '../../../execution/runner.js'
+import { BaseStep } from '../../../step/base-step.js'
+import { CaddyRuntime } from '../caddy-runtime.js'
+
+export class BootstrapCaddyStep extends BaseStep {
+  name(): string { return 'Bootstrap DEV-owned Caddy' }
+  id(): string { return 'caddy.bootstrap' }
+
+  async done(runner: Runner): Promise<boolean> {
+    const runtime = new CaddyRuntime()
+    if (runtime.platform === 'darwin') return existsSync(runner.config.globalPath('caddy/.pf-configured'))
+    if (!runtime.usesPrivilegedPorts()) return true
+    if (runtime.platform === 'linux') return runtime.hasLowPortAccess() && !runtime.systemServiceActive()
+    return false
+  }
+
+  async run(runner: Runner): Promise<boolean> {
+    const runtime = new CaddyRuntime()
+    if (runtime.platform !== 'darwin' && !runtime.usesPrivilegedPorts()) return true
+    if (runtime.platform === 'linux') {
+      for (const command of runtime.linuxBootstrapCommands()) {
+        const disablingService = command.includes('systemctl')
+        if (!await runner.exec(command) && !disablingService) return false
+      }
+      return runtime.hasLowPortAccess() && !runtime.systemServiceActive()
+    }
+
+    if (runtime.platform === 'darwin') {
+      const rulesFile = runner.config.globalPath('caddy/pf.conf')
+      writeFileSync(rulesFile,
+        `rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 80 -> 127.0.0.1 port ${runtime.httpPort()}\n`
+        + `rdr pass on lo0 inet proto tcp from any to 127.0.0.1 port 443 -> 127.0.0.1 port ${runtime.httpsPort()}\n`,
+      )
+      for (const command of runtime.darwinBootstrapCommands(rulesFile)) {
+        if (!await runner.exec(command)) return false
+      }
+      writeFileSync(runner.config.globalPath('caddy/.pf-configured'), 'configured\n')
+      return true
+    }
+    return false
+  }
+}

--- a/src/plugins/caddy/steps/caddy-site-step.ts
+++ b/src/plugins/caddy/steps/caddy-site-step.ts
@@ -1,49 +1,162 @@
 import { existsSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import { createHash } from 'node:crypto'
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
-import type { RawCaddySite } from '../caddy-step-resolver.js'
+import type { RawCaddyRoute, RawCaddySite } from '../caddy-step-resolver.js'
+import { caddySiteFilename } from '../caddy-layout.js'
 
 export class CaddySiteStep extends BaseStep {
   readonly host: string
   readonly proxy: string | null
+  readonly root: string | null
+  readonly phpFastcgi: string | null
   readonly secure: boolean
+  readonly tls: 'automatic' | 'internal'
+  readonly maxRequestBody: string | null
+  readonly responseHeaders: Record<string, string>
+  readonly requestHeaders: Record<string, string>
+  readonly flushInterval: string | null
+  readonly routes: RawCaddyRoute[]
 
   constructor(site: RawCaddySite, private readonly sitesDir: string) {
     super()
     if (typeof site === 'string') {
       this.host = site
       this.proxy = null
-      this.secure = false
+      this.root = null
+      this.phpFastcgi = null
+      this.secure = true
+      this.tls = 'internal'
+      this.maxRequestBody = null
+      this.responseHeaders = {}
+      this.requestHeaders = {}
+      this.flushInterval = null
+      this.routes = []
     } else {
       this.host = site.host
       this.proxy = site.proxy ?? null
-      this.secure = site.secure ?? false
+      this.root = site.root ?? null
+      this.phpFastcgi = site.php_fastcgi ?? null
+      this.secure = site.secure ?? true
+      this.tls = site.tls ?? 'internal'
+      this.maxRequestBody = site.max_request_body ?? null
+      this.responseHeaders = site.response_headers ?? {}
+      this.requestHeaders = site.request_headers ?? {}
+      this.flushInterval = site.flush_interval ?? null
+      this.routes = site.routes ?? []
     }
   }
 
   name(): string {
-    return this.proxy
+    return this.phpFastcgi
+      ? `Caddy: serve PHP ${this.host} via ${this.phpFastcgi}`
+      : this.proxy
       ? `Caddy: proxy ${this.host} → ${this.proxy}`
       : `Caddy: serve ${this.host}`
   }
 
   id(): string {
-    return `caddy-site-${createHash('md5').update(`${this.host}:${this.proxy ?? ''}:${this.secure}`).digest('hex')}`
+    const config = {
+      host: this.host,
+      proxy: this.proxy,
+      root: this.root,
+      phpFastcgi: this.phpFastcgi,
+      secure: this.secure,
+      tls: this.tls,
+      maxRequestBody: this.maxRequestBody,
+      responseHeaders: this.responseHeaders,
+      requestHeaders: this.requestHeaders,
+      flushInterval: this.flushInterval,
+      routes: this.routes,
+    }
+    return `caddy-site-${createHash('md5').update(JSON.stringify(config)).digest('hex')}`
   }
 
   private confPath(): string {
-    return join(this.sitesDir, `${this.host}.conf`)
+    return join(this.sitesDir, caddySiteFilename(this.host))
   }
 
   private buildConf(runner: Runner): string {
-    const addr = `https://${this.host}`
-    if (this.proxy) {
-      return `${addr} {\n  reverse_proxy ${this.proxy}\n}\n`
+    const scheme = this.secure ? 'https' : 'http'
+    const addr = `${scheme}://${this.host}`
+    const directives: string[] = []
+
+    if (this.secure && this.tls === 'internal') {
+      directives.push('\ttls internal')
     }
 
-    return `${addr} {\n  root * ${runner.config.cwd()}\n  file_server\n}\n`
+    if (this.maxRequestBody) {
+      directives.push(`\trequest_body {\n\t\tmax_size ${this.maxRequestBody}\n\t}`)
+    }
+
+    const responseHeaders = Object.entries(this.responseHeaders)
+    if (responseHeaders.length > 0) {
+      directives.push(this.buildHeaders(this.responseHeaders, '\t'))
+    }
+
+    for (const route of this.routes) {
+      const routeDirectives: string[] = []
+      if (route.strip_prefix) routeDirectives.push(`\t\turi strip_prefix ${route.strip_prefix}`)
+      if (Object.keys(route.response_headers ?? {}).length > 0) {
+        routeDirectives.push(this.buildHeaders(route.response_headers ?? {}, '\t\t'))
+      }
+      if (route.proxy) {
+        routeDirectives.push(this.buildProxy(
+          route.proxy,
+          route.request_headers ?? {},
+          route.flush_interval ?? null,
+          '\t\t',
+        ))
+      }
+      if (route.file_server) routeDirectives.push('\t\tfile_server')
+      directives.push(`\thandle ${route.path} {\n${routeDirectives.join('\n')}\n\t}`)
+    }
+
+    if (this.phpFastcgi) {
+      const root = this.root
+        ? (isAbsolute(this.root) ? this.root : resolve(runner.config.cwd(), this.root))
+        : runner.config.cwd()
+      directives.push(`\troot * ${this.quote(root)}`, `\tphp_fastcgi ${this.quote(this.phpFastcgi)}`, '\tfile_server')
+      return `${addr} {\n${directives.join('\n')}\n}\n`
+    }
+
+    if (this.proxy) {
+      const proxy = this.buildProxy(this.proxy, this.requestHeaders, this.flushInterval, '\t\t')
+      directives.push(this.routes.length > 0
+        ? `\thandle {\n${proxy}\n\t}`
+        : proxy.replace(/^\t\t/gm, '\t'))
+      return `${addr} {\n${directives.join('\n')}\n}\n`
+    }
+
+    directives.push(`\troot * ${this.quote(runner.config.cwd())}`, '\tfile_server')
+    return `${addr} {\n${directives.join('\n')}\n}\n`
+  }
+
+  private buildHeaders(headers: Record<string, string>, indent: string): string {
+    const values = Object.entries(headers)
+      .map(([name, value]) => `${indent}\t?${name} "${value}"`)
+      .join('\n')
+    return `${indent}header {\n${values}\n${indent}}`
+  }
+
+  private quote(value: string): string {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
+  }
+
+  private buildProxy(
+    proxy: string,
+    requestHeaders: Record<string, string>,
+    flushInterval: string | null,
+    indent: string,
+  ): string {
+    const options = [
+      ...Object.entries(requestHeaders).map(([name, value]) => `${indent}\theader_up ${name} "${value}"`),
+      ...(flushInterval ? [`${indent}\tflush_interval ${flushInterval}`] : []),
+    ]
+    return options.length > 0
+      ? `${indent}reverse_proxy ${proxy} {\n${options.join('\n')}\n${indent}}`
+      : `${indent}reverse_proxy ${proxy}`
   }
 
   async done(runner: Runner): Promise<boolean> {

--- a/src/plugins/caddy/steps/caddy-step.ts
+++ b/src/plugins/caddy/steps/caddy-step.ts
@@ -3,15 +3,24 @@ import type { Step } from '../../../types/step.js'
 import type { Runner } from '../../../execution/runner.js'
 import { CaddySiteStep } from './caddy-site-step.js'
 import type { RawCaddyConfig } from '../caddy-step-resolver.js'
+import { existsSync, lstatSync, mkdirSync, readdirSync, unlinkSync } from 'node:fs'
+import { join } from 'node:path'
+import { caddySiteFilename } from '../caddy-layout.js'
 
 export class CaddyStep implements Step {
   private readonly subSteps: Step[]
   private readonly _id: string
+  private readonly sites: NonNullable<RawCaddyConfig['sites']>
 
-  constructor(config: RawCaddyConfig, sitesDir: string) {
+  constructor(
+    config: RawCaddyConfig,
+    private readonly sitesDir: string,
+    private readonly deploy?: (runner: Runner) => Promise<boolean>,
+  ) {
     this.subSteps = []
+    this.sites = config.sites ?? []
 
-    for (const site of config.sites ?? []) {
+    for (const site of this.sites) {
       this.subSteps.push(new CaddySiteStep(site, sitesDir))
     }
 
@@ -31,6 +40,19 @@ export class CaddyStep implements Step {
   }
 
   async run(runner: Runner): Promise<boolean> {
-    return runner.execute(this.subSteps)
+    if (!existsSync(this.sitesDir)) mkdirSync(this.sitesDir, { recursive: true })
+
+    const expected = new Set(this.sites.map(site => caddySiteFilename(
+      typeof site === 'string' ? site : site.host,
+    )))
+    for (const file of readdirSync(this.sitesDir)) {
+      if (!file.endsWith('.conf') || expected.has(file)) continue
+      const path = join(this.sitesDir, file)
+      const stat = lstatSync(path)
+      if (stat.isFile() || stat.isSymbolicLink()) unlinkSync(path)
+    }
+
+    if (!await runner.execute(this.subSteps)) return false
+    return this.deploy ? this.deploy(runner) : true
   }
 }

--- a/src/plugins/caddy/steps/install-caddy-step.ts
+++ b/src/plugins/caddy/steps/install-caddy-step.ts
@@ -1,16 +1,18 @@
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
+import { PackageManager } from '../../core/config/package-manager.js'
 
 export class InstallCaddyStep extends BaseStep {
   name(): string { return 'Install Caddy' }
   id(): string { return 'caddy.install' }
 
   async done(runner: Runner): Promise<boolean> {
-    return runner.hasCommand('caddy')
+    return runner.hasCommand('caddy') && (process.platform !== 'linux' || runner.hasCommand('setcap'))
   }
 
   async run(runner: Runner): Promise<boolean> {
-    const caddyBin = runner.config.brewPath('bin/caddy')
-    return runner.exec(`brew install caddy && ${caddyBin} trust`)
+    const manager = PackageManager.detect()
+    const packages = process.platform === 'linux' ? ['caddy', 'setcap'] : ['caddy']
+    return runner.exec(manager.installCommand(manager.resolve(packages)))
   }
 }

--- a/src/plugins/caddy/steps/post-up-step.ts
+++ b/src/plugins/caddy/steps/post-up-step.ts
@@ -1,30 +1,22 @@
-import { existsSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
 import type { DeferredStep } from '../../../types/step.js'
+import { CaddyManager } from '../caddy-manager.js'
 
 export class PostUpStep extends BaseStep implements DeferredStep {
   readonly deferred = true as const
 
-  constructor(private readonly sites: string[]) {
-    super()
-  }
+  constructor(private readonly sites: string[]) { super() }
 
   name(): string | null { return null }
+  id(): string { return `caddy.post-up.${createHash('md5').update(this.sites.join(',')).digest('hex')}` }
 
-  id(): string {
-    return `caddy.post-up.${createHash('md5').update(this.sites.join(',')).digest('hex')}`
-  }
-
-  async done(_runner: Runner): Promise<boolean> {
-    return this.sites.length === 0
+  async done(runner: Runner): Promise<boolean> {
+    return new CaddyManager(runner.config).isDeployed()
   }
 
   async run(runner: Runner): Promise<boolean> {
-    const caddyfile = runner.config.globalPath('caddy/Caddyfile')
-    const caddyBin = runner.config.brewPath('bin/caddy')
-    if (!existsSync(caddyBin) || !existsSync(caddyfile)) return true
-    return runner.exec([caddyBin, 'reload', '--config', caddyfile])
+    return new CaddyManager(runner.config).deploy(runner)
   }
 }

--- a/src/plugins/caddy/steps/prepare-caddy-step.ts
+++ b/src/plugins/caddy/steps/prepare-caddy-step.ts
@@ -2,6 +2,9 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
+import { z } from 'zod'
+
+const caddyMetadataSchema = z.record(z.string(), z.unknown())
 
 export class PrepareCaddyStep extends BaseStep {
   name(): string { return 'Prepare Caddy' }
@@ -13,39 +16,23 @@ export class PrepareCaddyStep extends BaseStep {
 
   async run(runner: Runner): Promise<boolean> {
     const caddyDir = runner.config.globalPath('caddy')
-    const sitesDir = runner.config.globalPath('caddy/sites')
+    const projectsDir = runner.config.globalPath('caddy/projects')
+    const logsDir = runner.config.globalPath('caddy/logs')
     const caddyfile = join(caddyDir, 'Caddyfile')
 
-    if (!existsSync(sitesDir)) {
-      mkdirSync(sitesDir, { recursive: true })
+    if (!existsSync(projectsDir)) {
+      mkdirSync(projectsDir, { recursive: true })
     }
-
-    const importLine = `import ${sitesDir}/*`
-    const existingContent = existsSync(caddyfile) ? readFileSync(caddyfile, 'utf8') : ''
-    if (existingContent.trim() !== importLine) {
-      writeFileSync(caddyfile, importLine + '\n')
-    }
+    if (!existsSync(logsDir)) mkdirSync(logsDir, { recursive: true })
 
     const configFile = join(caddyDir, 'config.json')
     const configData = existsSync(configFile)
-      ? (JSON.parse(readFileSync(configFile, 'utf8')) as Record<string, unknown>)
+      ? caddyMetadataSchema.parse(JSON.parse(readFileSync(configFile, 'utf8')))
       : {}
-    configData['sitesDir'] = sitesDir
+    delete configData['sitesDir']
+    configData['projectsDir'] = projectsDir
     configData['caddyfile'] = caddyfile
     writeFileSync(configFile, JSON.stringify(configData, null, 2))
-
-    const caddyBin = runner.config.brewPath('bin/caddy')
-    if (existsSync(caddyBin)) {
-      const running = Bun.spawnSync(['sh', '-c', 'curl -sf http://localhost:2019/config/ > /dev/null 2>&1']).exitCode === 0
-      if (!running) {
-        if (!await runner.exec(`${caddyBin} start --config ${caddyfile}`)) return false
-        await new Promise(resolve => setTimeout(resolve, 1000))
-      } else {
-        if (!await runner.exec([caddyBin, 'reload', '--config', caddyfile])) return false
-      }
-      // trust after caddy is running so it can reach the admin API
-      await runner.exec(`${caddyBin} trust`)
-    }
 
     return true
   }

--- a/src/plugins/composer/steps/ensure-composer-step.ts
+++ b/src/plugins/composer/steps/ensure-composer-step.ts
@@ -1,15 +1,14 @@
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
+import { PackageManager } from '../../core/config/package-manager.js'
 
 export class EnsureComposerStep extends BaseStep {
   name(): string { return 'Ensure Composer is installed' }
   id(): string { return 'ensure-composer' }
 
   async run(runner: Runner): Promise<boolean> {
-    // Install composer via brew if not available
-    return runner.withoutShadowEnv().exec([
-      runner.config.brewPath('bin/brew'), 'install', 'composer',
-    ], undefined, { HOMEBREW_NO_AUTO_UPDATE: '1' })
+    const manager = PackageManager.detect()
+    return runner.withoutShadowEnv().exec(manager.installCommand(manager.resolve(['composer'])))
   }
 
   async done(runner: Runner): Promise<boolean> {

--- a/src/plugins/core/config/dns-config.ts
+++ b/src/plugins/core/config/dns-config.ts
@@ -1,0 +1,56 @@
+import { UserException } from '../../../exceptions.js'
+import { elevationTool, type ElevationTool } from '../../../execution/privilege.js'
+import { z } from 'zod'
+
+export const dnsConfigSchema = z.object({
+  server: z.string().min(1),
+  domains: z.array(z.string().min(1)).min(1),
+  docker_network: z.string().min(1).optional(),
+  interface: z.string().min(1).optional(),
+})
+
+export type RawDnsConfig = z.infer<typeof dnsConfigSchema>
+
+export class DnsConfig {
+  constructor(private readonly config: RawDnsConfig) {}
+
+  server(): string { return this.config.server }
+  domains(): string[] { return this.config.domains }
+
+  interface(
+    inspect: (network: string) => { id: string; bridge: string } = DnsConfig.inspectDockerNetwork,
+  ): string {
+    if (this.config.interface) return this.config.interface
+    if (!this.config.docker_network) {
+      throw new UserException('DNS configuration requires either an interface or docker_network key.')
+    }
+
+    const network = inspect(this.config.docker_network)
+    if (network.bridge) return network.bridge
+    if (!network.id) throw new UserException(`Docker network '${this.config.docker_network}' does not exist.`)
+    return `br-${network.id.slice(0, 12)}`
+  }
+
+  configureCommands(interfaceName: string, elevation: ElevationTool = elevationTool()): string[][] {
+    if (process.platform !== 'linux') {
+      throw new UserException('The DNS step currently supports Linux with systemd-resolved only.')
+    }
+
+    return [
+      [elevation, 'resolvectl', 'dns', interfaceName, this.server()],
+      [elevation, 'resolvectl', 'domain', interfaceName, ...this.domains().map(domain => `~${domain}`)],
+      [elevation, 'resolvectl', 'default-route', interfaceName, 'no'],
+    ]
+  }
+
+  private static inspectDockerNetwork(network: string): { id: string; bridge: string } {
+    const proc = Bun.spawnSync([
+      'docker', 'network', 'inspect', network,
+      '--format', '{{.Id}}|{{index .Options "com.docker.network.bridge.name"}}',
+    ])
+    if (proc.exitCode !== 0) return { id: '', bridge: '' }
+    const [id = '', rawBridge = ''] = new TextDecoder().decode(proc.stdout).trim().split('|')
+    const bridge = rawBridge === '<no value>' ? '' : rawBridge
+    return { id, bridge }
+  }
+}

--- a/src/plugins/core/config/mysql-config.ts
+++ b/src/plugins/core/config/mysql-config.ts
@@ -4,11 +4,14 @@ import { EnsureDockerStep } from '../steps/mysql/ensure-docker-step.js'
 import { StartContainerStep } from '../steps/mysql/start-container-step.js'
 import { UpdateEnvironmentStep } from '../steps/mysql/update-environment-step.js'
 import { CreateDatabaseStep } from '../steps/mysql/create-database-step.js'
+import { z } from 'zod'
 
-export type RawMySqlConfig = {
-  databases: string | string[]
-  version?: string
-}
+const databaseNameSchema = z.string().min(1).regex(/^[A-Za-z0-9_$-]+$/)
+export const mysqlConfigSchema = z.object({
+  databases: z.union([databaseNameSchema, z.array(databaseNameSchema).min(1)]),
+  version: z.string().min(1).optional(),
+})
+export type RawMySqlConfig = z.infer<typeof mysqlConfigSchema>
 
 export class MySqlConfig {
   constructor(

--- a/src/plugins/core/config/package-manager.ts
+++ b/src/plugins/core/config/package-manager.ts
@@ -1,0 +1,129 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { UserException } from '../../../exceptions.js'
+import { elevationTool, type ElevationTool } from '../../../execution/privilege.js'
+import { z } from 'zod'
+
+export const packageManagerNameSchema = z.enum(['apt', 'brew', 'pacman'])
+export type PackageManagerName = z.infer<typeof packageManagerNameSchema>
+
+export const packageSchema = z.union([
+  z.string().min(1),
+  z.object({
+    name: z.string().min(1),
+    apt: z.string().min(1).optional(),
+    brew: z.string().min(1).optional(),
+    pacman: z.string().min(1).optional(),
+  }),
+])
+export type RawPackage = z.infer<typeof packageSchema>
+
+export const packagesConfigSchema = z.union([
+  z.array(packageSchema),
+  z.object({ manager: packageManagerNameSchema.optional(), install: z.array(packageSchema) }),
+])
+export type RawPackagesConfig = z.infer<typeof packagesConfigSchema>
+
+type PackageNames = Record<PackageManagerName, string | null>
+
+const PACKAGE_NAMES: Record<string, PackageNames> = {
+  'aws-cli': { apt: 'awscli', brew: 'awscli', pacman: 'aws-cli' },
+  caddy: { apt: 'caddy', brew: 'caddy', pacman: 'caddy' },
+  docker: { apt: 'docker.io', brew: 'docker', pacman: 'docker' },
+  gettext: { apt: 'gettext', brew: 'gettext', pacman: 'gettext' },
+  go: { apt: 'golang-go', brew: 'go', pacman: 'go' },
+  lsof: { apt: 'lsof', brew: 'lsof', pacman: 'lsof' },
+  node: { apt: 'nodejs', brew: 'node', pacman: 'nodejs' },
+  npm: { apt: 'npm', brew: 'node', pacman: 'npm' },
+  openssl: { apt: 'openssl', brew: 'openssl@3', pacman: 'openssl' },
+  php: { apt: 'php-cli', brew: 'php', pacman: 'php' },
+  'php-fpm': { apt: 'php-fpm', brew: 'php', pacman: 'php-fpm' },
+  composer: { apt: 'composer', brew: 'composer', pacman: 'composer' },
+  unzip: { apt: 'unzip', brew: 'unzip', pacman: 'unzip' },
+  redis: { apt: 'redis-server', brew: 'redis', pacman: 'valkey' },
+  s5cmd: { apt: null, brew: 'peak/tap/s5cmd', pacman: null },
+  setcap: { apt: 'libcap2-bin', brew: null, pacman: 'libcap' },
+  'go-air': { apt: null, brew: 'go-air', pacman: null },
+}
+
+export class PackageManager {
+  constructor(
+    public readonly name: PackageManagerName,
+    private readonly elevation: ElevationTool = elevationTool(),
+  ) {}
+
+  static detect(
+    platform = process.platform,
+    commandExists: (command: string) => boolean = command => Bun.which(command) !== null,
+    osReleasePath = '/etc/os-release',
+  ): PackageManager {
+    if (platform === 'darwin') {
+      if (!commandExists('brew')) throw new UserException('Homebrew is required to install packages on macOS.')
+      return new PackageManager('brew')
+    }
+
+    if (platform !== 'linux') {
+      throw new UserException(`Portable package installation is not supported on ${platform}.`)
+    }
+
+    const osRelease = existsSync(osReleasePath) ? readFileSync(osReleasePath, 'utf8') : ''
+    const distro = PackageManager.osReleaseValue(osRelease, 'ID')
+    const like = PackageManager.osReleaseValue(osRelease, 'ID_LIKE').split(/\s+/).filter(Boolean)
+
+    if ((distro === 'arch' || distro === 'omarchy' || like.includes('arch')) && commandExists('pacman')) {
+      return new PackageManager('pacman')
+    }
+
+    if ((distro === 'debian' || distro === 'ubuntu' || like.includes('debian') || like.includes('ubuntu'))
+      && commandExists('apt-get')) {
+      return new PackageManager('apt')
+    }
+
+    if (commandExists('pacman')) return new PackageManager('pacman')
+    if (commandExists('apt-get')) return new PackageManager('apt')
+    if (commandExists('brew')) return new PackageManager('brew')
+
+    throw new UserException('Could not detect a supported package manager. Supported managers: pacman, apt, brew.')
+  }
+
+  resolve(packages: RawPackage[]): string[] {
+    return [...new Set(packages.map(pkg => this.resolveOne(pkg)))]
+  }
+
+  installCommand(packages: string[]): string[] {
+    switch (this.name) {
+      case 'apt': return [this.elevation, 'apt-get', 'install', '-y', ...packages]
+      case 'brew': return ['brew', 'install', ...packages]
+      case 'pacman': return [this.elevation, 'pacman', '-S', '--needed', '--noconfirm', ...packages]
+    }
+  }
+
+  checkCommand(packageName: string): string[] {
+    switch (this.name) {
+      case 'apt': return ['dpkg-query', '-W', '-f=${Status}', packageName]
+      case 'brew': return ['brew', 'list', '--versions', packageName]
+      case 'pacman': return ['pacman', '-Q', packageName]
+    }
+  }
+
+  private resolveOne(pkg: RawPackage): string {
+    const id = typeof pkg === 'string' ? pkg : pkg.name
+    const explicit = typeof pkg === 'string' ? undefined : pkg[this.name]
+    if (explicit) return explicit
+
+    const mapped = PACKAGE_NAMES[id]?.[this.name]
+    if (mapped) return mapped
+
+    if (PACKAGE_NAMES[id] && mapped === null) {
+      throw new UserException(
+        `Package '${id}' has no ${this.name} package mapping. Provide an explicit '${this.name}' override or use a custom installer.`,
+      )
+    }
+
+    return id
+  }
+
+  private static osReleaseValue(content: string, key: string): string {
+    const line = content.split('\n').find(candidate => candidate.startsWith(`${key}=`))
+    return line?.slice(key.length + 1).replace(/^['"]|['"]$/g, '').toLowerCase() ?? ''
+  }
+}

--- a/src/plugins/core/config/service-manager.ts
+++ b/src/plugins/core/config/service-manager.ts
@@ -1,0 +1,48 @@
+import type { PackageManagerName } from './package-manager.js'
+import { UserException } from '../../../exceptions.js'
+import { elevationTool, type ElevationTool } from '../../../execution/privilege.js'
+import { z } from 'zod'
+
+type ServiceNames = Record<PackageManagerName, string | null>
+
+const SERVICE_NAMES: Record<string, ServiceNames> = {
+  redis: { apt: 'redis-server', brew: 'redis', pacman: 'valkey' },
+  caddy: { apt: 'caddy', brew: 'caddy', pacman: 'caddy' },
+  docker: { apt: 'docker', brew: null, pacman: 'docker' },
+}
+
+export const serviceConfigSchema = z.union([
+  z.string().min(1),
+  z.object({ name: z.string().min(1), unit: z.string().min(1).optional() }),
+])
+export type RawServiceConfig = z.infer<typeof serviceConfigSchema>
+
+export class ServiceManager {
+  constructor(
+    public readonly packageManager: PackageManagerName,
+    private readonly elevation: ElevationTool = elevationTool(),
+  ) {}
+
+  resolve(config: RawServiceConfig): string {
+    const name = typeof config === 'string' ? config : config.name
+    const override = typeof config === 'string' ? undefined : config.unit
+    if (override) return override
+
+    const mapped = SERVICE_NAMES[name]?.[this.packageManager]
+    if (mapped) return mapped
+    if (SERVICE_NAMES[name] && mapped === null) {
+      throw new UserException(`Service '${name}' is not supported by ${this.packageManager}.`)
+    }
+    return name
+  }
+
+  startCommand(service: string): string[] {
+    if (this.packageManager === 'brew') return ['brew', 'services', 'start', service]
+    return [this.elevation, 'systemctl', 'enable', '--now', service]
+  }
+
+  checkCommand(service: string): string[] {
+    if (this.packageManager === 'brew') return ['brew', 'services', 'info', service]
+    return ['systemctl', 'is-active', '--quiet', service]
+  }
+}

--- a/src/plugins/core/core-config-provider.ts
+++ b/src/plugins/core/core-config-provider.ts
@@ -8,6 +8,9 @@ import { PromptEnvStep } from './steps/prompt-env-step.js'
 import { ScriptResolver } from './resolvers/script-resolver.js'
 import { CommandResolver } from './resolvers/command-resolver.js'
 import { MySqlResolver } from './resolvers/mysql-resolver.js'
+import { PackagesResolver } from './resolvers/packages-resolver.js'
+import { ServiceResolver } from './resolvers/service-resolver.js'
+import { DnsResolver } from './resolvers/dns-resolver.js'
 
 export class CoreConfigProvider implements ConfigProvider {
   private readonly dev: Dev
@@ -17,12 +20,12 @@ export class CoreConfigProvider implements ConfigProvider {
   }
 
   steps(): Step[] {
-    return [
-      new PromptEnvStep(this.dev.config),
-      new EnsureShadowEnvStep(),
-      new ShadowEnvStep(this.dev),
-      new EnvSubstituteStep(this.dev.config),
-    ]
+    const steps: Step[] = [new PromptEnvStep(this.dev.config)]
+
+    steps.push(new EnsureShadowEnvStep(), new ShadowEnvStep(this.dev))
+
+    steps.push(new EnvSubstituteStep(this.dev.config))
+    return steps
   }
 
   validate(): boolean {
@@ -36,6 +39,9 @@ export class CoreConfigProvider implements ConfigProvider {
       custom: scriptResolver,
       command: new CommandResolver(this.dev.config.commands()),
       mysql: new MySqlResolver(this.dev),
+      packages: new PackagesResolver(),
+      service: new ServiceResolver(),
+      dns: new DnsResolver(),
     }
   }
 }

--- a/src/plugins/core/resolvers/dns-resolver.ts
+++ b/src/plugins/core/resolvers/dns-resolver.ts
@@ -1,0 +1,12 @@
+import type { Step, StepResolver } from '../../../types/step.js'
+import { dnsConfigSchema, DnsConfig } from '../config/dns-config.js'
+import { DnsStep } from '../steps/dns-step.js'
+import { UserException } from '../../../exceptions.js'
+
+export class DnsResolver implements StepResolver {
+  resolve(args: unknown): Step {
+    const result = dnsConfigSchema.safeParse(args)
+    if (!result.success) throw new UserException(`Invalid DNS configuration: ${result.error.message}`)
+    return new DnsStep(new DnsConfig(result.data))
+  }
+}

--- a/src/plugins/core/resolvers/mysql-resolver.ts
+++ b/src/plugins/core/resolvers/mysql-resolver.ts
@@ -1,23 +1,15 @@
 import type { Dev } from '../../../dev.js'
 import type { StepResolver, Step } from '../../../types/step.js'
-import type { RawMySqlConfig } from '../config/mysql-config.js'
-import { MySqlConfig } from '../config/mysql-config.js'
+import { mysqlConfigSchema, MySqlConfig } from '../config/mysql-config.js'
 import { UserException } from '../../../exceptions.js'
 
 export class MySqlResolver implements StepResolver {
   constructor(private readonly dev: Dev) {}
 
   resolve(args: unknown): Step {
-    if (!args || typeof args !== 'object') {
-      throw new Error('MySQL configuration should be an object!')
-    }
-
-    const raw = args as Record<string, unknown>
-    if (!raw['databases']) {
-      throw new UserException('MySQL configuration should have a databases key!')
-    }
-
-    const config = new MySqlConfig(raw as unknown as RawMySqlConfig, this.dev)
+    const result = mysqlConfigSchema.safeParse(args)
+    if (!result.success) throw new UserException(`Invalid MySQL configuration: ${result.error.message}`)
+    const config = new MySqlConfig(result.data, this.dev)
     // MySqlConfig returns multiple steps — wrap in a composite step
     return new MySqlCompositeStep(config)
   }

--- a/src/plugins/core/resolvers/packages-resolver.ts
+++ b/src/plugins/core/resolvers/packages-resolver.ts
@@ -1,0 +1,18 @@
+import type { StepResolver, Step } from '../../../types/step.js'
+import { PackageManager, packagesConfigSchema } from '../config/package-manager.js'
+import { PackagesStep } from '../steps/packages-step.js'
+import { UserException } from '../../../exceptions.js'
+
+export class PackagesResolver implements StepResolver {
+  resolve(args: unknown): Step {
+    const result = packagesConfigSchema.safeParse(args)
+    if (!result.success) throw new UserException(`Invalid packages configuration: ${result.error.message}`)
+    const config = result.data
+    const packages = Array.isArray(config) ? config : config.install
+    const manager = Array.isArray(config) || !config.manager
+      ? PackageManager.detect()
+      : new PackageManager(config.manager)
+
+    return new PackagesStep(manager, packages)
+  }
+}

--- a/src/plugins/core/resolvers/service-resolver.ts
+++ b/src/plugins/core/resolvers/service-resolver.ts
@@ -1,0 +1,14 @@
+import type { Step, StepResolver } from '../../../types/step.js'
+import { PackageManager } from '../config/package-manager.js'
+import { serviceConfigSchema, ServiceManager } from '../config/service-manager.js'
+import { ServiceStep } from '../steps/service-step.js'
+import { UserException } from '../../../exceptions.js'
+
+export class ServiceResolver implements StepResolver {
+  resolve(args: unknown): Step {
+    const result = serviceConfigSchema.safeParse(args)
+    if (!result.success) throw new UserException(`Invalid service configuration: ${result.error.message}`)
+    const manager = new ServiceManager(PackageManager.detect().name)
+    return new ServiceStep(manager, result.data)
+  }
+}

--- a/src/plugins/core/steps/clone-step.ts
+++ b/src/plugins/core/steps/clone-step.ts
@@ -1,8 +1,17 @@
-import { existsSync, mkdirSync, rmSync } from 'node:fs'
+import { existsSync, lstatSync, mkdirSync, rmSync } from 'node:fs'
+import { dirname, relative, resolve } from 'node:path'
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
 import type { ProjectDefinition } from '../../../config/project-definition.js'
 import { Config } from '../../../config/config.js'
+
+export function isRepairableManagedCheckout(root: string, path: string): boolean {
+  if (lstatSync(path).isSymbolicLink()) return false
+  const managedRoot = resolve(root, Config.SrcDir)
+  const candidate = resolve(path)
+  const child = relative(managedRoot, candidate)
+  return child !== '' && child !== '..' && !child.startsWith(`..${process.platform === 'win32' ? '\\' : '/'}`)
+}
 
 export class CloneStep extends BaseStep {
   constructor(
@@ -21,11 +30,19 @@ export class CloneStep extends BaseStep {
     const clonePath = this.clonePath(runner.config)
 
     if (existsSync(clonePath)) {
-      runner.getIO().writeln(`Repository already exists at ${clonePath}`)
-      return !this.update || this.pullChanges(runner, clonePath)
+      if (this.isGitRepository(clonePath)) {
+        runner.getIO().writeln(`Repository already exists at ${clonePath}`)
+        return !this.update || this.pullChanges(runner, clonePath)
+      }
+      if (!this.canRepair(clonePath)) {
+        runner.getIO().error(`Refusing to replace an invalid repository outside DEV's managed dependency directory: ${clonePath}`)
+        return false
+      }
+      runner.getIO().writeln(`Repairing incomplete repository at ${clonePath}`)
+      rmSync(clonePath, { recursive: true })
     }
 
-    mkdirSync(clonePath, { recursive: true })
+    mkdirSync(dirname(clonePath), { recursive: true })
 
     const extraArgs = Array.isArray(this.args) ? this.args : this.args ? [this.args] : []
     if (this.project.ref) extraArgs.push('--branch', this.project.ref)
@@ -48,5 +65,17 @@ export class CloneStep extends BaseStep {
 
   private clonePath(config: Config): string {
     return Config.sourcePath(this.project.repo, this.project.source, this.root ?? undefined)
+  }
+
+  private isGitRepository(path: string): boolean {
+    const result = Bun.spawnSync(['git', '-C', path, 'rev-parse', '--show-toplevel'], {
+      stdout: 'pipe', stderr: 'ignore',
+    })
+    return result.exitCode === 0
+      && resolve(result.stdout.toString().trim()) === resolve(path)
+  }
+
+  private canRepair(path: string): boolean {
+    return this.root !== null && isRepairableManagedCheckout(this.root, path)
   }
 }

--- a/src/plugins/core/steps/dns-step.ts
+++ b/src/plugins/core/steps/dns-step.ts
@@ -1,0 +1,26 @@
+import { createHash } from 'node:crypto'
+import type { Runner } from '../../../execution/runner.js'
+import { BaseStep } from '../../../step/base-step.js'
+import type { DnsConfig } from '../config/dns-config.js'
+
+export class DnsStep extends BaseStep {
+  constructor(private readonly dns: DnsConfig) { super() }
+
+  name(): string { return `Configure local DNS for ${this.dns.domains().join(', ')}` }
+  id(): string {
+    const value = `${this.dns.server()}:${this.dns.domains().join(',')}`
+    return `dns.${createHash('md5').update(value).digest('hex')}`
+  }
+
+  async run(runner: Runner): Promise<boolean> {
+    const interfaceName = this.dns.interface()
+    for (const command of this.dns.configureCommands(interfaceName)) {
+      if (!await runner.exec(command)) return false
+    }
+    return true
+  }
+
+  async done(_runner: Runner): Promise<boolean> {
+    return false
+  }
+}

--- a/src/plugins/core/steps/env-substitute-step.ts
+++ b/src/plugins/core/steps/env-substitute-step.ts
@@ -3,6 +3,9 @@ import type { Config } from '../../../config/config.js'
 import type { Runner } from '../../../execution/runner.js'
 import { BaseStep } from '../../../step/base-step.js'
 
+const MANAGED_START = '# DEV managed environment — generated from dev.yml'
+const MANAGED_END = '# End DEV managed environment'
+
 export class EnvSubstituteStep extends BaseStep {
   constructor(private readonly config: Config) {
     super()
@@ -24,23 +27,22 @@ export class EnvSubstituteStep extends BaseStep {
     }
 
     const sampleContent = readFileSync(cfg.cwd('.env.example'), 'utf8')
-    let envContent = existsSync(cfg.cwd('.env')) ? readFileSync(cfg.cwd('.env'), 'utf8') : ''
+    const originalContent = readFileSync(cfg.cwd('.env'), 'utf8')
+    let envContent = this.withoutManagedBlock(originalContent)
 
     const sampleEnvs = this.parseEnv(sampleContent)
-    const currentEnvs = this.parseEnv(envContent)
+    let currentEnvs = this.parseEnv(envContent)
 
     if (Object.keys(sampleEnvs).length > 0 && !envContent.endsWith('\n')) {
       envContent += '\n'
     }
 
-    let envWasAdded = false
     for (const [key, value] of Object.entries(sampleEnvs)) {
-      const insert = `${key}="${value ?? ''}"`
+      const insert = this.assignment(key, value ?? '')
       const exists = key in currentEnvs
 
       if (!exists) {
         envContent += insert + '\n'
-        envWasAdded = true
         continue
       }
 
@@ -49,34 +51,32 @@ export class EnvSubstituteStep extends BaseStep {
 
       const hasSampleValue = !['', 'null', 'NULL'].includes(value ?? '')
       if (!hasValue && hasSampleValue) {
-        const replaced = envContent.replace(new RegExp(`${key}=(.*)`, 'm'), insert)
-        if (replaced !== envContent) {
-          envContent = replaced
-          envWasAdded = true
-        }
+        envContent = envContent.replace(this.assignmentPattern(key), insert)
       }
     }
 
     // Config envs take precedence
     const configEnvs = await cfg.envs()
+    const managed: string[] = []
+    currentEnvs = this.parseEnv(envContent)
     for (const [key, value] of configEnvs) {
-      const insert = `${key}="${value}"`
-      if (!new RegExp(`^${key}=(.*)`, 'm').test(envContent)) {
-        if (!envContent.endsWith('\n')) envContent += '\n'
-        envContent += insert + '\n'
-        envWasAdded = true
-      } else {
-        const replaced = envContent.replace(new RegExp(`^${key}=(.*)`, 'm'), insert)
-        if (replaced !== envContent) {
-          envContent = replaced
-          envWasAdded = true
-        }
+      const insert = this.assignment(key, value)
+      if (key in sampleEnvs) {
+        envContent = key in currentEnvs
+          ? envContent.replace(this.assignmentPattern(key), insert)
+          : envContent + insert + '\n'
+        continue
       }
+      envContent = envContent.replace(this.assignmentLinePattern(key), '')
+      managed.push(insert)
     }
 
-    if (envWasAdded) {
-      envContent = envContent.replace(/\n{3,}/g, '\n\n')
-      if (!envContent.endsWith('\n')) envContent += '\n'
+    envContent = envContent.replace(/\n{3,}/g, '\n\n').trimEnd() + '\n'
+    if (managed.length > 0) {
+      envContent += `\n${MANAGED_START}\n${managed.join('\n')}\n${MANAGED_END}\n`
+    }
+
+    if (envContent !== originalContent) {
       writeFileSync(cfg.cwd('.env'), envContent)
     }
 
@@ -102,6 +102,30 @@ export class EnvSubstituteStep extends BaseStep {
       result[key] = val
     }
     return result
+  }
+
+  private assignment(key: string, value: string): string {
+    return `${key}='${value.replaceAll("'", "\\'")}'`
+  }
+
+  private assignmentPattern(key: string): RegExp {
+    return new RegExp(`^${this.escapeRegExp(key)}=.*$`, 'm')
+  }
+
+  private assignmentLinePattern(key: string): RegExp {
+    return new RegExp(`^${this.escapeRegExp(key)}=.*(?:\\n|$)`, 'm')
+  }
+
+  private escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  }
+
+  private withoutManagedBlock(content: string): string {
+    const start = content.indexOf(MANAGED_START)
+    if (start === -1) return content
+    const end = content.indexOf(MANAGED_END, start)
+    if (end === -1) return content.slice(0, start)
+    return content.slice(0, start) + content.slice(end + MANAGED_END.length).replace(/^\n/, '')
   }
 
   id(): string {

--- a/src/plugins/core/steps/mysql/create-database-step.ts
+++ b/src/plugins/core/steps/mysql/create-database-step.ts
@@ -18,22 +18,31 @@ export class CreateDatabaseStep extends BaseStep {
 
   async run(runner: Runner): Promise<boolean> {
     const dbs = Array.isArray(this.databases) ? this.databases : [this.databases]
-    const sql = dbs.map(db => `CREATE DATABASE IF NOT EXISTS ${db};`).join(' ')
-    const cmd = `docker exec -i dev-mysql mysql -u${CreateDatabaseStep.User} -e "${sql}"`
-
-    for (const delay of [1000, 2000, 3000]) {
-      const ok = await runner.exec(cmd)
-      if (ok) return true
-      await Bun.sleep(delay)
-    }
-    return false
+    const sql = dbs.map(db => `CREATE DATABASE IF NOT EXISTS \`${db}\`;`).join(' ')
+    if (!await this.waitUntilReady()) return false
+    return runner.exec([
+      'docker', 'exec', '-i', 'dev-mysql', 'mysql', `-u${CreateDatabaseStep.User}`, '-e', sql,
+    ])
   }
 
   async done(runner: Runner): Promise<boolean> {
     const dbs = Array.isArray(this.databases) ? this.databases : [this.databases]
-    const cmd = `docker exec dev-mysql mysql -u${CreateDatabaseStep.User} -e "SHOW DATABASES;"`
-    const proc = Bun.spawnSync(['sh', '-c', cmd])
+    const proc = Bun.spawnSync([
+      'docker', 'exec', 'dev-mysql', 'mysql', `-u${CreateDatabaseStep.User}`, '-e', 'SHOW DATABASES;',
+    ])
     const output = new TextDecoder().decode(proc.stdout)
-    return dbs.every(db => output.includes(db))
+    return proc.exitCode === 0 && dbs.every(db => output.split('\n').includes(db))
+  }
+
+  private async waitUntilReady(timeoutMs = 60_000): Promise<boolean> {
+    const deadline = Date.now() + timeoutMs
+    while (Date.now() < deadline) {
+      const result = Bun.spawnSync([
+        'docker', 'exec', 'dev-mysql', 'mysqladmin', 'ping', `-u${CreateDatabaseStep.User}`, '--silent',
+      ], { stdout: 'ignore', stderr: 'ignore' })
+      if (result.exitCode === 0) return true
+      await Bun.sleep(1000)
+    }
+    return false
   }
 }

--- a/src/plugins/core/steps/mysql/ensure-docker-step.ts
+++ b/src/plugins/core/steps/mysql/ensure-docker-step.ts
@@ -1,5 +1,11 @@
 import type { Runner } from '../../../../execution/runner.js'
 import { BaseStep } from '../../../../step/base-step.js'
+import { z } from 'zod'
+
+const dockerInfoSchema = z.object({
+  ID: z.string().min(1),
+  ClientInfo: z.object({ Context: z.string() }),
+})
 
 export class EnsureDockerStep extends BaseStep {
   private orbStackInstalled = false
@@ -65,9 +71,8 @@ export class EnsureDockerStep extends BaseStep {
     const proc = Bun.spawnSync(['docker', 'info', '--format=json'])
     if (proc.exitCode !== 0) return false
     try {
-      const info = JSON.parse(new TextDecoder().decode(proc.stdout)) as Record<string, unknown>
-      const clientInfo = info['ClientInfo'] as Record<string, unknown> | undefined
-      return Boolean(info['ID']) && clientInfo?.['Context'] === 'orbstack'
+      const result = dockerInfoSchema.safeParse(JSON.parse(new TextDecoder().decode(proc.stdout)))
+      return result.success && result.data.ClientInfo.Context === 'orbstack'
     } catch {
       return false
     }

--- a/src/plugins/core/steps/packages-step.ts
+++ b/src/plugins/core/steps/packages-step.ts
@@ -1,0 +1,33 @@
+import { createHash } from 'node:crypto'
+import type { Runner } from '../../../execution/runner.js'
+import { BaseStep } from '../../../step/base-step.js'
+import type { PackageManager, RawPackage } from '../config/package-manager.js'
+
+export class PackagesStep extends BaseStep {
+  private readonly packages: string[]
+
+  constructor(private readonly manager: PackageManager, packages: RawPackage[]) {
+    super()
+    this.packages = manager.resolve(packages)
+  }
+
+  name(): string {
+    return `Install ${this.manager.name} packages: ${this.packages.join(', ')}`
+  }
+
+  async run(runner: Runner): Promise<boolean> {
+    return runner.exec(this.manager.installCommand(this.packages))
+  }
+
+  async done(runner: Runner): Promise<boolean> {
+    for (const pkg of this.packages) {
+      if (!await runner.withoutShadowEnv().exec(this.manager.checkCommand(pkg))) return false
+    }
+    return true
+  }
+
+  id(): string {
+    const value = `${this.manager.name}:${this.packages.join(',')}`
+    return `packages.${createHash('md5').update(value).digest('hex')}`
+  }
+}

--- a/src/plugins/core/steps/service-step.ts
+++ b/src/plugins/core/steps/service-step.ts
@@ -1,0 +1,23 @@
+import type { Runner } from '../../../execution/runner.js'
+import { BaseStep } from '../../../step/base-step.js'
+import type { RawServiceConfig, ServiceManager } from '../config/service-manager.js'
+
+export class ServiceStep extends BaseStep {
+  private readonly service: string
+
+  constructor(private readonly manager: ServiceManager, config: RawServiceConfig) {
+    super()
+    this.service = manager.resolve(config)
+  }
+
+  name(): string { return `Start service: ${this.service}` }
+  id(): string { return `service.${this.manager.packageManager}.${this.service}` }
+
+  async run(runner: Runner): Promise<boolean> {
+    return runner.exec(this.manager.startCommand(this.service))
+  }
+
+  async done(runner: Runner): Promise<boolean> {
+    return runner.withoutShadowEnv().exec(this.manager.checkCommand(this.service))
+  }
+}

--- a/src/plugins/core/steps/shadowenv/ensure-shadowenv-step.ts
+++ b/src/plugins/core/steps/shadowenv/ensure-shadowenv-step.ts
@@ -1,8 +1,18 @@
-import { existsSync, appendFileSync } from 'node:fs'
+import { existsSync, appendFileSync, chmodSync, mkdirSync, renameSync } from 'node:fs'
 import type { Runner } from '../../../../execution/runner.js'
 import { BaseStep } from '../../../../step/base-step.js'
 import { UserException } from '../../../../exceptions.js'
-import { BrewStep } from '../brew-step.js'
+
+const SHADOWENV_VERSION = '3.5.1'
+
+export function shadowenvAsset(platform = process.platform, arch = process.arch): string {
+  const targetPlatform = platform === 'darwin' ? 'apple-darwin' : platform === 'linux' ? 'unknown-linux-gnu' : null
+  const targetArch = arch === 'arm64' ? 'aarch64' : arch === 'x64' ? 'x86_64' : null
+  if (!targetPlatform || !targetArch) {
+    throw new UserException(`Shadowenv does not provide a binary for ${platform}/${arch}.`)
+  }
+  return `shadowenv-${targetArch}-${targetPlatform}`
+}
 
 export class EnsureShadowEnvStep extends BaseStep {
   private installed = false
@@ -14,8 +24,17 @@ export class EnsureShadowEnvStep extends BaseStep {
 
   async run(runner: Runner): Promise<boolean> {
     if (!this.installed) {
-      const installed = await runner.withoutShadowEnv().execute(new BrewStep(['shadowenv']))
-      if (!installed) return false
+      const target = runner.config.globalBinPath('shadowenv')
+      const temporary = `${target}.download`
+      const asset = shadowenvAsset()
+      const url = `https://github.com/Shopify/shadowenv/releases/download/${SHADOWENV_VERSION}/${asset}`
+      const response = await fetch(url)
+      if (!response.ok) return false
+      mkdirSync(runner.config.globalBinPath(), { recursive: true })
+      await Bun.write(temporary, response)
+      chmodSync(temporary, 0o755)
+      renameSync(temporary, target)
+      this.installed = true
     }
 
     if (this.hookInstalled) return true
@@ -29,7 +48,7 @@ export class EnsureShadowEnvStep extends BaseStep {
       throw new UserException(`Unable to find the profile file: ${shell.profile}. Please setup Shadowenv manually.`)
     }
 
-    const evalLine = this.evalConfig(shell.name)
+    const evalLine = this.evalConfig(shell.name, runner.shadowenvBin())
     try {
       appendFileSync(shell.profile, evalLine)
     } catch {
@@ -39,8 +58,9 @@ export class EnsureShadowEnvStep extends BaseStep {
     return this.done(runner)
   }
 
-  private evalConfig(shell: string): string {
-    return `\n# Shadow Env\neval "$(shadowenv init ${shell})"\n`
+  private evalConfig(shell: string, binary: string): string {
+    if (shell === 'fish') return `\n# Shadow Env\n${binary} init fish | source\n`
+    return `\n# Shadow Env\neval "$(${binary} init ${shell})"\n`
   }
 
   async done(runner: Runner): Promise<boolean> {

--- a/src/plugins/core/steps/shadowenv/shadowenv-step.ts
+++ b/src/plugins/core/steps/shadowenv/shadowenv-step.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs'
 import type { Dev } from '../../../../dev.js'
 import type { Runner } from '../../../../execution/runner.js'
 import { BaseStep } from '../../../../step/base-step.js'
@@ -19,8 +18,7 @@ export class ShadowEnvStep extends BaseStep {
 
   async done(runner: Runner): Promise<boolean> {
     if (!runner.config.isDevProject()) return true
-    const shadowenvDir = this.dev.config.cwd('.shadowenv.d')
-    return existsSync(shadowenvDir)
+    return this.dev.environmentIsCurrent()
   }
 
   id(): string {

--- a/src/plugins/php-runtime/php-runtime-plugin.ts
+++ b/src/plugins/php-runtime/php-runtime-plugin.ts
@@ -1,0 +1,27 @@
+import type { PluginInterface, Capable } from '../../types/plugin.js'
+import type { Capability, CapabilityKey } from '../../types/capability.js'
+import { CONFIG_PROVIDER, ENV_PROVIDER, PATH_PROVIDER, SERVE_PROVIDER } from '../../types/capability.js'
+import type { Dev } from '../../dev.js'
+import {
+  PhpRuntimeConfigProvider,
+  PhpRuntimeEnvProvider,
+  PhpRuntimePathProvider,
+  PhpRuntimeServeProvider,
+} from './php-runtime-providers.js'
+
+export class PhpRuntimePlugin implements PluginInterface, Capable {
+  static readonly NAME = 'php-runtime'
+  readonly PLUGIN_API_VERSION = '0.0.0'
+  activate(_dev: Dev): void {}
+  deactivate(_dev: Dev): void {}
+  uninstall(_dev: Dev): void {}
+
+  capabilities(): Partial<Record<CapabilityKey, new (args: Record<string, unknown>) => Capability>> {
+    return {
+      [CONFIG_PROVIDER]: PhpRuntimeConfigProvider,
+      [ENV_PROVIDER]: PhpRuntimeEnvProvider,
+      [PATH_PROVIDER]: PhpRuntimePathProvider,
+      [SERVE_PROVIDER]: PhpRuntimeServeProvider,
+    }
+  }
+}

--- a/src/plugins/php-runtime/php-runtime-providers.ts
+++ b/src/plugins/php-runtime/php-runtime-providers.ts
@@ -1,0 +1,48 @@
+import type { ConfigProvider, EnvProvider, PathProvider, ServeProvider } from '../../types/capability.js'
+import type { Step, StepResolver } from '../../types/step.js'
+import type { Dev } from '../../dev.js'
+import { PhpRuntime } from './php-runtime.js'
+import { PhpRuntimeStep } from './php-runtime-step.js'
+import { pluginDev } from '../../plugin/plugin-args.js'
+
+abstract class PhpProviderBase {
+  protected readonly dev: Dev
+  constructor(args: Record<string, unknown>) { this.dev = pluginDev(args) }
+}
+
+export class PhpRuntimeConfigProvider extends PhpProviderBase implements ConfigProvider {
+  steps(): Step[] {
+    return PhpRuntime.definitions(this.dev.config).map(([name]) => new PhpRuntimeStep(this.dev.config, name))
+  }
+  validate(): boolean { return true }
+  stepResolvers(): Record<string, StepResolver> { return {} }
+}
+
+export class PhpRuntimeEnvProvider extends PhpProviderBase implements EnvProvider {
+  envs(): Record<string, string> {
+    const primary = PhpRuntime.primary(this.dev.config)
+    if (!primary) return {}
+    const runtime = PhpRuntime.resolve(this.dev.config, primary[0])
+    return {
+      PHP_BIN: runtime.phpBinary,
+      DEV_PHP_VERSION: runtime.version,
+      PHP_INI_SCAN_DIR: runtime.iniDir,
+    }
+  }
+}
+
+export class PhpRuntimePathProvider extends PhpProviderBase implements PathProvider {
+  paths(): string[] {
+    return PhpRuntime.definitions(this.dev.config)
+      .map(([name]) => PhpRuntime.resolve(this.dev.config, name).binDir)
+  }
+}
+
+export class PhpRuntimeServeProvider extends PhpProviderBase implements ServeProvider {
+  processes(): Record<string, { run: string }> {
+    return Object.fromEntries(PhpRuntime.definitions(this.dev.config).map(([name]) => {
+      const runtime = PhpRuntime.resolve(this.dev.config, name)
+      return [`php:${name}`, { run: `"${runtime.binDir}/php-fpm" --nodaemonize --force-stderr --fpm-config "${runtime.fpmConfig}"` }]
+    }))
+  }
+}

--- a/src/plugins/php-runtime/php-runtime-step.ts
+++ b/src/plugins/php-runtime/php-runtime-step.ts
@@ -1,0 +1,160 @@
+import { existsSync, lstatSync, mkdirSync, readFileSync, symlinkSync, unlinkSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { z } from 'zod'
+import type { Config } from '../../config/config.js'
+import type { Runner } from '../../execution/runner.js'
+import { UserException } from '../../exceptions.js'
+import { BaseStep } from '../../step/base-step.js'
+import { PackageManager } from '../core/config/package-manager.js'
+import { PhpRuntime, type NativePhpRuntime, type ResolvedPhpRuntime, type SpcPhpRuntime } from './php-runtime.js'
+
+const runtimeMetadataSchema = z.object({
+  provider: z.enum(['native', 'spc']),
+  version: z.string(),
+  extensions: z.array(z.string()),
+})
+
+export class PhpRuntimeStep extends BaseStep {
+  constructor(private readonly config: Config, private readonly runtimeName: string) { super() }
+
+  name(): string { return `Prepare PHP runtime: ${this.runtimeName}` }
+  id(): string { return `php-runtime-${this.runtimeName}` }
+
+  async done(): Promise<boolean> {
+    const runtime = PhpRuntime.resolve(this.config, this.runtimeName)
+    const metadata = join(runtime.root, 'runtime.json')
+    if (!existsSync(metadata) || !existsSync(runtime.fpmConfig)) return false
+    try {
+      const recorded = runtimeMetadataSchema.parse(JSON.parse(readFileSync(metadata, 'utf8')))
+      return recorded.provider === runtime.provider
+        && recorded.version === runtime.version
+        && JSON.stringify(recorded.extensions) === JSON.stringify(runtime.extensions)
+        && existsSync(runtime.phpBinary)
+        && existsSync(runtime.fpmBinary)
+        && existsSync(runtime.iniFile)
+        && readFileSync(runtime.iniFile, 'utf8') === this.extensionsContent(runtime)
+        && readFileSync(runtime.fpmConfig, 'utf8') === this.fpmContent(runtime)
+        && this.extensionsAvailable(runtime, runtime.phpBinary)
+    } catch {
+      return false
+    }
+  }
+
+  async run(runner: Runner): Promise<boolean> {
+    const runtime = PhpRuntime.resolve(this.config, this.runtimeName)
+    const prepared = runtime.provider === 'native'
+      ? await this.prepareNative(runner, runtime)
+      : await this.prepareSpc(runner, runtime)
+    if (!prepared || !this.extensionsAvailable(runtime, runtime.phpBinary)) return false
+
+    mkdirSync(runtime.iniDir, { recursive: true })
+    writeFileSync(runtime.iniFile, this.extensionsContent(runtime))
+    mkdirSync(dirname(runtime.fpmConfig), { recursive: true })
+    writeFileSync(runtime.fpmConfig, this.fpmContent(runtime))
+    writeFileSync(join(runtime.root, 'runtime.json'), JSON.stringify({
+      provider: runtime.provider,
+      version: runtime.version,
+      extensions: runtime.extensions,
+    }, null, 2) + '\n')
+    return true
+  }
+
+  private async prepareNative(runner: Runner, runtime: NativePhpRuntime): Promise<boolean> {
+    const manager = PackageManager.detect()
+    const missing = runtime.packages.filter(packageName =>
+      Bun.spawnSync(manager.checkCommand(packageName), { stdout: 'ignore', stderr: 'ignore' }).exitCode !== 0
+    )
+    if (missing.length > 0 && !await runner.exec(manager.installCommand(missing))) return false
+    const php = this.binary(runtime.sourcePhpBinary)
+    const fpm = this.binary(runtime.sourceFpmBinary)
+    if (!php || !fpm) return false
+    mkdirSync(runtime.binDir, { recursive: true })
+    this.replaceLink(runtime.phpBinary, php)
+    this.replaceLink(runtime.fpmBinary, fpm)
+    return true
+  }
+
+  private async prepareSpc(runner: Runner, runtime: SpcPhpRuntime): Promise<boolean> {
+    if (existsSync(runtime.phpBinary) && existsSync(runtime.fpmBinary)
+      && this.extensionsAvailable(runtime, runtime.phpBinary)) return true
+    const direct = runner.withoutShadowEnv()
+    const environment = runtime.target ? { SPC_TARGET: runtime.target } : {}
+    if (!existsSync(runtime.spcBinary) && !await this.installSpc(direct, runtime)) return false
+    if (!await this.installSpcRequirements(direct)) return false
+    mkdirSync(runtime.root, { recursive: true })
+    this.prepareSpcCaches(runtime)
+    if (!await direct.exec([runtime.spcBinary, 'doctor', '--auto-fix', '--no-interaction'], runtime.root, environment)) return false
+    if (!await direct.exec([runtime.spcBinary, 'doctor', '--no-interaction'], runtime.root, environment)) return false
+    const extensions = runtime.extensions.join(',')
+    if (!await direct.exec([
+      runtime.spcBinary, 'download', `--for-extensions=${extensions}`, `--with-php=${runtime.version}`,
+    ], runtime.root, environment)) return false
+    return direct.exec([runtime.spcBinary, 'build', extensions, '--build-cli', '--build-fpm'], runtime.root, environment)
+  }
+
+  private prepareSpcCaches(runtime: SpcPhpRuntime): void {
+    mkdirSync(runtime.downloadCache, { recursive: true })
+    const downloads = join(runtime.root, 'downloads')
+    if (!existsSync(downloads)) symlinkSync(runtime.downloadCache, downloads, 'dir')
+    mkdirSync(runtime.toolchainCache, { recursive: true })
+    const toolchain = join(runtime.root, 'pkgroot')
+    if (!existsSync(toolchain)) symlinkSync(runtime.toolchainCache, toolchain, 'dir')
+  }
+
+  private async installSpcRequirements(runner: Runner): Promise<boolean> {
+    const manager = PackageManager.detect()
+    const packages = manager.resolve(['cmake', 're2c'])
+    const missing = packages.filter(packageName =>
+      Bun.spawnSync(manager.checkCommand(packageName), { stdout: 'ignore', stderr: 'ignore' }).exitCode !== 0
+    )
+    return missing.length === 0 || runner.exec(manager.installCommand(missing))
+  }
+
+  private async installSpc(runner: Runner, runtime: SpcPhpRuntime): Promise<boolean> {
+    const platform = process.platform === 'linux' ? 'linux' : process.platform === 'darwin' ? 'macos' : null
+    const architecture = process.arch === 'x64' ? 'x86_64' : process.arch === 'arm64' ? 'aarch64' : null
+    if (!platform || !architecture) throw new UserException(`SPC does not support ${process.platform}/${process.arch}.`)
+    const binDir = dirname(runtime.spcBinary)
+    const archive = join(binDir, `spc-${platform}-${architecture}.tar.gz`)
+    const url = `https://github.com/crazywhalecc/static-php-cli/releases/latest/download/spc-${platform}-${architecture}.tar.gz`
+    mkdirSync(binDir, { recursive: true })
+    if (!await runner.exec(['curl', '-fL', '-o', archive, url])) return false
+    if (!await runner.exec(['tar', '-xzf', archive, '-C', binDir])) return false
+    return runner.exec(['chmod', '0755', runtime.spcBinary])
+  }
+
+  private binary(candidate: string): string | null {
+    return candidate.startsWith('/') ? (existsSync(candidate) ? candidate : null) : Bun.which(candidate)
+  }
+
+  private replaceLink(path: string, target: string): void {
+    try { lstatSync(path); unlinkSync(path) } catch {}
+    symlinkSync(target, path)
+  }
+
+  private fpmContent(runtime: ResolvedPhpRuntime): string {
+    return `[global]\ndaemonize = no\nerror_log = syslog\n\n[${runtime.name}]\n`
+      + `listen = ${runtime.socketPath}\nlisten.mode = 0600\npm = ondemand\npm.max_children = 8\n`
+      + `pm.process_idle_timeout = 10s\nclear_env = no\ncatch_workers_output = yes\n`
+  }
+
+  private extensionsContent(runtime: ResolvedPhpRuntime): string {
+    if (runtime.provider === 'spc') return ''
+    return runtime.extensions.filter(extension => !this.extensionLoaded(runtime.phpBinary, extension))
+      .map(extension => `extension=${extension}\n`).join('')
+  }
+
+  private extensionLoaded(php: string, extension: string, iniDir?: string): boolean {
+    const expression = extension === 'mbregex'
+      ? "function_exists('mb_split')"
+      : `extension_loaded('${extension}')`
+    return Bun.spawnSync([php, '-r', `exit(${expression} ? 0 : 1);`], {
+      env: iniDir ? { ...process.env, PHP_INI_SCAN_DIR: iniDir } : process.env,
+      stdout: 'ignore', stderr: 'ignore',
+    }).exitCode === 0
+  }
+
+  private extensionsAvailable(runtime: ResolvedPhpRuntime, php: string): boolean {
+    return runtime.extensions.every(extension => this.extensionLoaded(php, extension, runtime.iniDir))
+  }
+}

--- a/src/plugins/php-runtime/php-runtime.ts
+++ b/src/plugins/php-runtime/php-runtime.ts
@@ -1,0 +1,178 @@
+import { createHash } from 'node:crypto'
+import { join } from 'node:path'
+import { z } from 'zod'
+import type { Config } from '../../config/config.js'
+import { UserException } from '../../exceptions.js'
+import type { RawRuntime } from '../../types/config.js'
+import { PackageManager, type PackageManagerName } from '../core/config/package-manager.js'
+
+const brewInfoSchema = z.object({ formulae: z.array(z.object({ versions: z.object({ stable: z.string().nullable() }) })) })
+
+type RuntimeCommon = {
+  name: string; requirement: string; version: string; phpBinary: string; fpmBinary: string
+  socketPath: string; root: string; binDir: string; fpmConfig: string; extensions: string[]
+  iniDir: string; iniFile: string
+}
+export type NativePhpRuntime = RuntimeCommon & {
+  provider: 'native'
+  packages: string[]
+  sourcePhpBinary: string
+  sourceFpmBinary: string
+}
+export type SpcPhpRuntime = RuntimeCommon & {
+  provider: 'spc'; spcBinary: string; target: string | null; downloadCache: string; toolchainCache: string
+}
+export type ResolvedPhpRuntime = NativePhpRuntime | SpcPhpRuntime
+type NativeCandidate = {
+  version: string; cliPackage: string; fpmPackage: string; phpBinary: string; fpmBinary: string; extensionPrefix: string
+}
+
+export class PhpRuntime {
+  private static readonly candidateCache = new Map<string, NativeCandidate[]>()
+
+  static definitions(config: Config): Array<[string, RawRuntime]> {
+    return Object.entries(config.runtimes()).filter(([, runtime]) => (runtime.type ?? 'php') === 'php')
+  }
+
+  static resolve(config: Config, name: string, manager = PackageManager.detect()): ResolvedPhpRuntime {
+    const raw = this.definition(config, name)
+    if ((raw.server ?? 'fpm') !== 'fpm') throw new UserException(`Unsupported PHP server for '${name}'.`)
+    const requirement = raw.version ?? '*'
+    const provider = raw.provider ?? 'auto'
+    const extensions = [...new Set(raw.extensions ?? [])].sort()
+    const native = provider === 'spc' ? undefined : this.cachedCandidates(manager.name, requirement)
+      .find(candidate => this.satisfies(candidate.version, requirement))
+    if (native) return this.nativeRuntime(config, name, requirement, extensions, native, manager.name)
+    if (provider === 'native') throw new UserException(`The native ${manager.name} repositories cannot satisfy PHP '${requirement}'.`)
+    return this.spcRuntime(config, name, requirement, extensions)
+  }
+
+  static endpoint(config: Config, name: string): string {
+    this.definition(config, name)
+    return `unix/${config.devPath(`runtimes/${name}/php-fpm.sock`)}`
+  }
+
+  static primary(config: Config): [string, RawRuntime] | null {
+    const definitions = this.definitions(config)
+    if (definitions.length === 0) return null
+    const namedPhp = definitions.find(([name]) => name === 'php')
+    if (namedPhp) return namedPhp
+    if (definitions.length === 1) return definitions[0]!
+    throw new UserException("Multiple PHP runtimes require one runtime named 'php' to select the project default.")
+  }
+
+  static satisfies(version: string, requirement: string): boolean {
+    if (!requirement || requirement === '*' || requirement === 'latest') return true
+    const actual = this.parts(version)
+    if (/^\d+\.\d+$/.test(requirement)) return actual[0] === Number(requirement.split('.')[0]) && actual[1] === Number(requirement.split('.')[1])
+    if (/^\d+\.\d+\.\d+$/.test(requirement)) return this.compare(actual, this.parts(requirement)) === 0
+    if (requirement.startsWith('^')) {
+      const minimum = this.parts(requirement.slice(1))
+      return this.compare(actual, minimum) >= 0 && actual[0] === minimum[0]
+    }
+    return requirement.split(/\s+/).every(token => {
+      const match = token.match(/^(>=|<=|>|<|=)?(\d+(?:\.\d+){0,2})$/)
+      if (!match) return false
+      const comparison = this.compare(actual, this.parts(match[2]!))
+      return match[1] === '>=' ? comparison >= 0 : match[1] === '<=' ? comparison <= 0
+        : match[1] === '>' ? comparison > 0 : match[1] === '<' ? comparison < 0 : comparison === 0
+    })
+  }
+
+  private static nativeRuntime(config: Config, name: string, requirement: string, extensions: string[], candidate: NativeCandidate, manager: PackageManagerName): NativePhpRuntime {
+    const versionLine = candidate.version.match(/^\d+\.\d+/)?.[0] ?? candidate.version
+    const root = config.globalPath(`runtimes/php/${versionLine}/native`)
+    return {
+      provider: 'native', name, requirement, version: candidate.version,
+      phpBinary: join(root, 'bin/php'), fpmBinary: join(root, 'bin/php-fpm'),
+      sourcePhpBinary: candidate.phpBinary, sourceFpmBinary: candidate.fpmBinary,
+      socketPath: config.devPath(`runtimes/${name}/php-fpm.sock`), root, binDir: join(root, 'bin'),
+      fpmConfig: config.devPath(`runtimes/${name}/php-fpm.conf`), extensions,
+      iniDir: config.devPath(`runtimes/${name}/php.d`), iniFile: config.devPath(`runtimes/${name}/php.d/extensions.ini`),
+      packages: [...new Set([candidate.cliPackage, candidate.fpmPackage, ...this.extensionPackages(manager, candidate.extensionPrefix, versionLine, extensions)])],
+    }
+  }
+
+  private static spcRuntime(config: Config, name: string, requirement: string, extensions: string[]): SpcPhpRuntime {
+    const version = requirement.match(/^(\d+\.\d+)(?:\.\d+)?$/)?.[1]
+    if (!version) throw new UserException(`SPC requires an exact PHP minor version such as '8.4'; '${requirement}' is ambiguous.`)
+    const target = process.platform === 'linux' ? 'native-native-gnu' : null
+    const fingerprint = createHash('sha256').update(JSON.stringify({ version, extensions, target })).digest('hex').slice(0, 16)
+    const root = config.globalPath(`runtimes/php/${version}/spc/${fingerprint}`)
+    const binDir = join(root, 'buildroot/bin')
+    return {
+      provider: 'spc', name, requirement, version, phpBinary: join(binDir, 'php'), fpmBinary: join(binDir, 'php-fpm'),
+      socketPath: config.devPath(`runtimes/${name}/php-fpm.sock`), root, binDir,
+      fpmConfig: config.devPath(`runtimes/${name}/php-fpm.conf`), extensions,
+      iniDir: config.devPath(`runtimes/${name}/php.d`), iniFile: config.devPath(`runtimes/${name}/php.d/extensions.ini`),
+      spcBinary: config.globalPath('bin/spc'),
+      target,
+      downloadCache: config.globalPath(`runtimes/php/${version}/spc/downloads`),
+      toolchainCache: config.globalPath(`runtimes/php/${version}/spc/toolchains/${target ?? 'native'}`),
+    }
+  }
+
+  private static candidates(manager: PackageManagerName, requirement: string): NativeCandidate[] {
+    if (manager === 'pacman') return [
+      this.pacmanCandidate('php', 'php-fpm', 'php', 'php-fpm'),
+      this.pacmanCandidate('php-legacy', 'php-legacy-fpm', 'php-legacy', 'php-fpm-legacy'),
+    ].filter((candidate): candidate is NativeCandidate => candidate !== null)
+    const exactLine = requirement.match(/^(?:\^)?(\d+\.\d+)$/)?.[1]
+    if (manager === 'apt') {
+      const names = exactLine ? [[`php${exactLine}-cli`, `php${exactLine}-fpm`, `/usr/bin/php${exactLine}`, `/usr/sbin/php-fpm${exactLine}`]] : [['php-cli', 'php-fpm', '/usr/bin/php', '/usr/sbin/php-fpm']]
+      return names.map(([cli, fpm, phpBin, fpmBin]) => this.aptCandidate(cli!, fpm!, phpBin!, fpmBin!)).filter((candidate): candidate is NativeCandidate => candidate !== null)
+    }
+    const formula = exactLine ? `php@${exactLine}` : 'php'
+    const info = Bun.spawnSync(['brew', 'info', '--json=v2', formula], { stdout: 'pipe', stderr: 'pipe' })
+    if (info.exitCode !== 0) return []
+    const version = brewInfoSchema.parse(JSON.parse(info.stdout.toString())).formulae[0]?.versions.stable
+    if (!version) return []
+    const prefix = join(Bun.spawnSync(['brew', '--prefix'], { stdout: 'pipe', stderr: 'pipe' }).stdout.toString().trim(), 'opt', formula)
+    return [{ version, cliPackage: formula, fpmPackage: formula, phpBinary: join(prefix, 'bin/php'), fpmBinary: join(prefix, 'sbin/php-fpm'), extensionPrefix: formula }]
+  }
+
+  private static cachedCandidates(manager: PackageManagerName, requirement: string): NativeCandidate[] {
+    const key = `${manager}:${requirement}`
+    const existing = this.candidateCache.get(key)
+    if (existing) return existing
+    const candidates = this.candidates(manager, requirement)
+    this.candidateCache.set(key, candidates)
+    return candidates
+  }
+
+  private static definition(config: Config, name: string): RawRuntime {
+    const raw = config.runtimes()[name]
+    if (!raw || (raw.type ?? 'php') !== 'php') throw new UserException(`Unknown PHP runtime '${name}'.`)
+    return raw
+  }
+
+  private static pacmanCandidate(cliPackage: string, fpmPackage: string, phpBinary: string, fpmBinary: string): NativeCandidate | null {
+    const result = Bun.spawnSync(['pacman', '-Si', cliPackage], { stdout: 'pipe', stderr: 'pipe' })
+    const version = result.exitCode === 0 ? result.stdout.toString().match(/^Version\s*:\s*([^\s-]+)/m)?.[1] : undefined
+    return version ? { version, cliPackage, fpmPackage, phpBinary, fpmBinary, extensionPrefix: cliPackage } : null
+  }
+
+  private static aptCandidate(cliPackage: string, fpmPackage: string, phpBinary: string, fpmBinary: string): NativeCandidate | null {
+    const result = Bun.spawnSync(['apt-cache', 'policy', cliPackage], { stdout: 'pipe', stderr: 'pipe' })
+    const version = result.exitCode === 0 ? result.stdout.toString().match(/Candidate:\s*(?:\d+:)?([^\s~+-]+)/)?.[1] : undefined
+    return version && version !== '(none)' ? { version, cliPackage, fpmPackage, phpBinary, fpmBinary, extensionPrefix: `php${version.match(/^\d+\.\d+/)?.[0] ?? ''}` } : null
+  }
+
+  private static extensionPackages(manager: PackageManagerName, prefix: string, version: string, extensions: string[]): string[] {
+    if (manager === 'brew') return []
+    return extensions.flatMap(extension => {
+      const packageName = manager === 'pacman' ? `${prefix}-${extension === 'mysqli' ? 'mysql' : extension}` : `php${version}-${extension}`
+      const result = Bun.spawnSync(manager === 'pacman' ? ['pacman', '-Si', packageName] : ['apt-cache', 'policy', packageName], { stdout: 'pipe', stderr: 'ignore' })
+      return result.exitCode !== 0 || (manager === 'apt' && result.stdout.toString().includes('Candidate: (none)')) ? [] : [packageName]
+    })
+  }
+
+  private static parts(version: string): [number, number, number] {
+    const values = version.match(/\d+/g)?.slice(0, 3).map(Number) ?? []
+    return [values[0] ?? 0, values[1] ?? 0, values[2] ?? 0]
+  }
+  private static compare(a: [number, number, number], b: [number, number, number]): number {
+    for (let i = 0; i < 3; i++) if (a[i] !== b[i]) return a[i]! - b[i]!
+    return 0
+  }
+}

--- a/src/plugins/valet/config/local-valet-config.ts
+++ b/src/plugins/valet/config/local-valet-config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Config } from '../../../config/config.js'
 import { UserException } from '../../../exceptions.js'
+import { z } from 'zod'
 
 export type LocalValetConfigData = {
   dir: string
@@ -11,6 +12,16 @@ export type LocalValetConfigData = {
   tld: string
   php: string
 }
+
+const localValetConfigSchema = z.object({
+  dir: z.string().optional(),
+  bin: z.string().optional(),
+  version: z.string().optional(),
+  path: z.string().optional(),
+  tld: z.string().optional(),
+  domain: z.string().optional(),
+  php: z.string().optional(),
+})
 
 export class LocalValetConfig {
   private config: LocalValetConfigData
@@ -47,12 +58,16 @@ export class LocalValetConfig {
     const configPath = join(valetDir, 'config.json')
     if (!existsSync(configPath)) return {}
     try {
-      const data = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>
-      if (data['domain']) {
-        data['tld'] = data['domain']
-        delete data['domain']
-      }
-      return data as Partial<LocalValetConfigData>
+      const data = localValetConfigSchema.parse(JSON.parse(readFileSync(configPath, 'utf8')))
+      const config: Partial<LocalValetConfigData> = {}
+      if (data.dir !== undefined) config.dir = data.dir
+      if (data.bin !== undefined) config.bin = data.bin
+      if (data.version !== undefined) config.version = data.version
+      if (data.path !== undefined) config.path = data.path
+      if (data.php !== undefined) config.php = data.php
+      if (data.domain !== undefined) config.tld = data.domain
+      else if (data.tld !== undefined) config.tld = data.tld
+      return config
     } catch {
       return {}
     }

--- a/src/plugins/valet/steps/extension-install-step.ts
+++ b/src/plugins/valet/steps/extension-install-step.ts
@@ -6,8 +6,8 @@ import type { Config } from '../../../config/config.js'
 import { UserException } from '../../../exceptions.js'
 
 export type RawExtensionConfig = {
-  before?: string
-  options?: Record<string, string>
+  before?: string | undefined
+  options?: Record<string, string> | undefined
 }
 
 export type RawExtensionsMap = Record<string, RawExtensionConfig | null>
@@ -91,12 +91,15 @@ export class ExtensionInstallStep extends BaseStep {
 
   private extensionPath(): string {
     const phpBin = this.devConfig.path('bin/php')
+    const inheritedEnv = Object.fromEntries(
+      Object.entries(process.env).filter((item): item is [string, string] => item[1] !== undefined),
+    )
     const result = Bun.spawnSync(
       // ini_get('extension_dir') returns the runtime value set by php.ini (where pecl installs);
       // PHP_EXTENSION_DIR is the compiled-in default which may differ from the actual pecl ext_dir
       [phpBin, '-r', "echo ini_get('extension_dir');"],
       // PHP_INI_SCAN_DIR='' suppresses scan dirs but still loads main php.ini (so extension_dir is correct)
-      { stdout: 'pipe', stderr: 'pipe', env: { ...process.env as Record<string, string>, PHP_INI_SCAN_DIR: '' } },
+      { stdout: 'pipe', stderr: 'pipe', env: { ...inheritedEnv, PHP_INI_SCAN_DIR: '' } },
     )
     if (result.exitCode !== 0) throw new UserException('Failed to get PHP extension directory')
     const extDir = new TextDecoder().decode(result.stdout).trim()

--- a/src/plugins/valet/steps/prepare-valet-step.ts
+++ b/src/plugins/valet/steps/prepare-valet-step.ts
@@ -45,10 +45,13 @@ export class PrepareValetStep extends BaseStep {
 
     for (const bin of candidates) {
       if (!existsSync(bin)) continue
+      const inheritedEnv = Object.fromEntries(
+        Object.entries(process.env).filter((item): item is [string, string] => item[1] !== undefined),
+      )
       const result = Bun.spawnSync([bin, '--version'], {
         stdout: 'pipe',
         stderr: 'pipe',
-        env: process.env as Record<string, string>,
+        env: inheritedEnv,
       })
       if (result.exitCode !== 0) continue
       const lines = new TextDecoder().decode(result.stdout).trim().split('\n').filter(l => l.trim())

--- a/src/plugins/valet/steps/site-step.ts
+++ b/src/plugins/valet/steps/site-step.ts
@@ -3,7 +3,7 @@ import type { Runner } from '../../../execution/runner.js'
 import type { LocalValetConfig } from '../config/local-valet-config.js'
 import { createHash } from 'node:crypto'
 
-export type RawSite = string | { host: string; proxy?: string; secure?: boolean }
+export type RawSite = string | { host: string; proxy?: string | undefined; secure?: boolean | undefined }
 
 export class SiteStep implements Step {
   readonly host: string

--- a/src/plugins/valet/steps/valet-step.ts
+++ b/src/plugins/valet/steps/valet-step.ts
@@ -7,14 +7,14 @@ import { ExtensionInstallStep, type RawExtensionsMap } from './extension-install
 import type { LocalValetConfig } from '../config/local-valet-config.js'
 import type { Dev } from '../../../dev.js'
 
-type RawPhpObject = {
-  version?: string | number
-  extensions?: RawExtensionsMap
+export type RawPhpObject = {
+  version?: string | number | undefined
+  extensions?: RawExtensionsMap | undefined
 }
 
-type RawValetConfig = {
-  php?: string | number | RawPhpObject
-  sites?: RawSite[]
+export type RawValetConfig = {
+  php?: string | number | RawPhpObject | undefined
+  sites?: RawSite[] | undefined
 }
 
 function normalizePhpVersion(version: unknown): string | null {
@@ -38,7 +38,7 @@ export class ValetStep implements Step {
         this.subSteps.push(new LinkPhpStep(phpVersion, localConfig, dev))
       }
     } else if (config.php && typeof config.php === 'object') {
-      const phpObj = config.php as RawPhpObject
+      const phpObj = config.php
       phpVersion = normalizePhpVersion(phpObj.version)
       if (phpVersion && localConfig && dev) {
         this.subSteps.push(new LinkPhpStep(phpVersion, localConfig, dev))

--- a/src/plugins/valet/valet-command-provider.ts
+++ b/src/plugins/valet/valet-command-provider.ts
@@ -2,12 +2,14 @@ import type { Command } from '@oclif/core'
 import type { CommandProvider } from '../../types/capability.js'
 import type { RawCommand } from '../../types/config.js'
 import type { Dev } from '../../dev.js'
+import { pluginDev } from '../../plugin/plugin-args.js'
+import { rawValetConfigSchema } from './valet-step-resolver.js'
 
 export class ValetCommandProvider implements CommandProvider {
   private readonly dev: Dev
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
+    this.dev = pluginDev(args)
   }
 
   getCommands(): Command.Class[] {
@@ -16,7 +18,11 @@ export class ValetCommandProvider implements CommandProvider {
 
   getConfigCommands(): Record<string, RawCommand> {
     const rawSteps = this.dev.config.raw_().steps ?? this.dev.config.raw_().up ?? []
-    const hasValet = rawSteps.some(s => s && typeof s === 'object' && 'valet' in s)
+    const hasValet = rawSteps.some(step => {
+      if (!('valet' in step)) return false
+      rawValetConfigSchema.parse(step['valet'])
+      return true
+    })
     if (!hasValet) return {}
 
     return {

--- a/src/plugins/valet/valet-config-provider.ts
+++ b/src/plugins/valet/valet-config-provider.ts
@@ -2,31 +2,35 @@ import type { ConfigProvider } from '../../types/capability.js'
 import type { Step, StepResolver } from '../../types/step.js'
 import type { Dev } from '../../dev.js'
 import type { ValetPlugin } from './valet-plugin.js'
-import { ValetStepResolver } from './valet-step-resolver.js'
+import { rawValetConfigSchema, ValetStepResolver } from './valet-step-resolver.js'
 import { InstallValetStep } from './steps/install-valet-step.js'
 import { PrepareValetStep } from './steps/prepare-valet-step.js'
 import { PostUpStep } from './steps/post-up-step.js'
+import { valetProviderArgs } from './valet-provider-args.js'
 
 export class ValetConfigProvider implements ConfigProvider {
   private readonly dev: Dev
   private readonly plugin: ValetPlugin
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
-    this.plugin = args['plugin'] as ValetPlugin
+    const parsed = valetProviderArgs(args)
+    this.dev = parsed.dev
+    this.plugin = parsed.plugin
   }
 
   steps(): Step[] {
     const rawSteps = this.dev.config.raw_().steps ?? this.dev.config.raw_().up ?? []
+    const valetSteps = rawSteps.filter(rawStep => 'valet' in rawStep)
+
+    if (valetSteps.length === 0) return []
+
     const sites: string[] = []
-    for (const rawStep of rawSteps) {
-      if (!rawStep || typeof rawStep !== 'object') continue
-      const v = (rawStep as Record<string, unknown>)['valet'] as Record<string, unknown> | undefined
-      if (!v) continue
-      const rawSites = v['sites']
+    for (const rawStep of valetSteps) {
+      const v = rawValetConfigSchema.parse(rawStep['valet'])
+      const rawSites = v.sites
       if (Array.isArray(rawSites)) {
         for (const site of rawSites) {
-          const host = typeof site === 'string' ? site : (site as Record<string, string>)['host']
+          const host = typeof site === 'string' ? site : site.host
           if (host) sites.push(host)
         }
       }

--- a/src/plugins/valet/valet-env-provider.ts
+++ b/src/plugins/valet/valet-env-provider.ts
@@ -3,17 +3,26 @@ import { realpathSync } from 'node:fs'
 import type { EnvProvider } from '../../types/capability.js'
 import type { Dev } from '../../dev.js'
 import type { ValetPlugin } from './valet-plugin.js'
+import { rawValetConfigSchema } from './valet-step-resolver.js'
+import { valetProviderArgs } from './valet-provider-args.js'
 
 export class ValetEnvProvider implements EnvProvider {
   private readonly dev: Dev
   private readonly plugin: ValetPlugin
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
-    this.plugin = args['plugin'] as ValetPlugin
+    const parsed = valetProviderArgs(args)
+    this.dev = parsed.dev
+    this.plugin = parsed.plugin
   }
 
   envs(): Record<string, string> {
+    const steps = this.dev.config.raw_().steps ?? this.dev.config.raw_().up ?? []
+    if (!steps.some(step => {
+      if (!('valet' in step)) return false
+      rawValetConfigSchema.parse(step['valet'])
+      return true
+    })) return {}
     if (!this.plugin.localConfig) return {}
 
     const env = this.plugin.localConfig
@@ -38,6 +47,7 @@ export class ValetEnvProvider implements EnvProvider {
       SITE_PATH: sitesPath,
       VALET_OR_HERD_SITE_PATH: sitesPath,
       PHP_INI_SCAN_DIR: iniScanDir,
+      LOCAL_DEV_CA_CERT_PATH: join(valetPath, 'CA', 'LaravelValetCASelfSigned.pem'),
     }
   }
 }

--- a/src/plugins/valet/valet-path-provider.ts
+++ b/src/plugins/valet/valet-path-provider.ts
@@ -2,14 +2,16 @@ import { dirname } from 'node:path'
 import type { PathProvider } from '../../types/capability.js'
 import type { Dev } from '../../dev.js'
 import type { ValetPlugin } from './valet-plugin.js'
+import { valetProviderArgs } from './valet-provider-args.js'
 
 export class ValetPathProvider implements PathProvider {
   private readonly dev: Dev
   private readonly plugin: ValetPlugin
 
   constructor(args: Record<string, unknown>) {
-    this.dev = args['dev'] as Dev
-    this.plugin = args['plugin'] as ValetPlugin
+    const parsed = valetProviderArgs(args)
+    this.dev = parsed.dev
+    this.plugin = parsed.plugin
   }
 
   paths(): string[] {

--- a/src/plugins/valet/valet-provider-args.ts
+++ b/src/plugins/valet/valet-provider-args.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod'
+import { Dev } from '../../dev.js'
+import { ValetPlugin } from './valet-plugin.js'
+
+const valetProviderArgsSchema = z.object({
+  dev: z.instanceof(Dev),
+  plugin: z.lazy(() => z.instanceof(ValetPlugin)),
+})
+
+export function valetProviderArgs(args: Record<string, unknown>): z.infer<typeof valetProviderArgsSchema> {
+  return valetProviderArgsSchema.parse(args)
+}

--- a/src/plugins/valet/valet-step-resolver.ts
+++ b/src/plugins/valet/valet-step-resolver.ts
@@ -1,10 +1,26 @@
 import type { StepResolver, Step } from '../../types/step.js'
 import type { ValetPlugin } from './valet-plugin.js'
 import { ValetStep } from './steps/valet-step.js'
-import type { RawSite } from './steps/site-step.js'
 import type { Dev } from '../../dev.js'
+import { z } from 'zod'
 
-type RawValetConfig = { php?: string | Record<string, unknown>; sites?: RawSite[] }
+const rawSiteSchema = z.union([z.string(), z.object({
+  host: z.string(),
+  proxy: z.string().optional(),
+  secure: z.boolean().optional(),
+})])
+const rawExtensionConfigSchema = z.object({
+  before: z.string().optional(),
+  options: z.record(z.string(), z.string()).optional(),
+})
+const rawPhpSchema = z.object({
+  version: z.union([z.string(), z.number()]).optional(),
+  extensions: z.record(z.string(), rawExtensionConfigSchema.nullable()).optional(),
+})
+export const rawValetConfigSchema = z.object({
+  php: z.union([z.string(), z.number(), rawPhpSchema]).optional(),
+  sites: z.array(rawSiteSchema).optional(),
+})
 
 export class ValetStepResolver implements StepResolver {
   constructor(private readonly plugin: ValetPlugin, private readonly dev: Dev) {}
@@ -12,7 +28,7 @@ export class ValetStepResolver implements StepResolver {
   resolve(args: unknown): Step {
     const valetBin = this.plugin.localConfig?.get('bin') ?? 'valet'
     return new ValetStep(
-      args as RawValetConfig,
+      rawValetConfigSchema.parse(args),
       valetBin,
       this.plugin.localConfig ?? undefined,
       this.dev,

--- a/src/process/serve-manager.ts
+++ b/src/process/serve-manager.ts
@@ -1,7 +1,9 @@
-import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs'
 import { join } from 'node:path'
 import type { Dev } from '../dev.js'
 import type { RawServe, RawServeProcess } from '../types/config.js'
+import type { ServeProvider } from '../types/capability.js'
+import { SERVE_PROVIDER } from '../types/capability.js'
 
 const COLORS = [2, 3, 4, 5, 6, 42, 130, 103, 129, 108]
 const SHOW_CURSOR = '\x1b[?25h'
@@ -109,10 +111,14 @@ export class ServeManager {
     }
 
     const serve = dev.config.getServe()
-    if (!serve || (typeof serve === 'object' && Object.keys(serve).length === 0)) return
+    const provided = dev.getPluginManager()
+      .getPluginCapabilities<ServeProvider>(SERVE_PROVIDER, { dev })
+      .reduce<Record<string, RawServe>>((all, provider) => ({ ...all, ...provider.processes() }), {})
+    if ((!serve || (typeof serve === 'object' && Object.keys(serve).length === 0))
+      && Object.keys(provided).length === 0) return
 
     const serves: Record<string, RawServe> =
-      typeof serve === 'string' ? { serve: serve } : serve
+      typeof serve === 'string' ? { ...provided, serve: serve } : { ...provided, ...serve }
 
     const projectName = dev.config.getName() || dev.config.projectName()
     const multiProject = !!parentName
@@ -122,26 +128,27 @@ export class ServeManager {
         // Flat serves always run — they are the shared layer
         const serveConfig = typeof rawServe === 'string' ? { run: rawServe } : rawServe
         const displayName = multiProject ? `${projectName}:${name}` : name
-        this.pushEntry(entries, dev, displayName, serveConfig)
+        await this.pushEntry(entries, dev, displayName, serveConfig)
       } else {
         // rawServe is a RawServeGroup — include all groups or only the requested ones
         if (groups && !groups.includes(name)) continue
         for (const [subName, subServe] of Object.entries(rawServe)) {
           const serveConfig = typeof subServe === 'string' ? { run: subServe } : subServe
           const displayName = multiProject ? `${projectName}:${name}:${subName}` : `${name}:${subName}`
-          this.pushEntry(entries, dev, displayName, serveConfig)
+          await this.pushEntry(entries, dev, displayName, serveConfig)
         }
       }
     }
   }
 
-  private pushEntry(
+  private async pushEntry(
     entries: ProcessEntry[],
     dev: Dev,
     displayName: string,
-    serveConfig: { run: string; env?: string | false; cwd?: string },
-  ): void {
-    const env = this.resolveDotenv(dev, serveConfig.env)
+    serveConfig: Exclude<RawServeProcess, string>,
+  ): Promise<void> {
+    const projectEnv = Object.fromEntries(await dev.resolveEnvs())
+    const dotenv = this.resolveDotenv(dev, serveConfig.env)
     const cwd = serveConfig.cwd
       ? join(dev.config.cwd(), serveConfig.cwd)
       : dev.config.cwd()
@@ -150,7 +157,7 @@ export class ServeManager {
       name: displayName.toLowerCase(),
       command: serveConfig.run,
       cwd,
-      env,
+      env: { ...projectEnv, ...dotenv, PATH: dev.effectivePath() },
       color: COLORS[entries.length % COLORS.length]!,
     })
   }
@@ -164,11 +171,7 @@ export class ServeManager {
     if (!existsSync(path)) return {}
 
     try {
-      const content = Bun.file(path).text()
-      const env: Record<string, string> = {}
-      // Simple .env parser
-      const text = Bun.readableStreamToText(Bun.file(path).stream()) as unknown as string
-      return env
+      return this.parseDotenv(readFileSync(path, 'utf8'))
     } catch {
       return {}
     }
@@ -200,21 +203,17 @@ export class ServeManager {
     for (const entry of entries) {
       writeOutputLine(`${colorPrefix(entry.name, entry.color)}\x1b[1mRunning...\x1b[0m`)
 
-      const dotenvPath = join(entry.cwd, '.env')
-      let dotenv: Record<string, string> = {}
-      if (existsSync(dotenvPath)) {
-        const content = await Bun.file(dotenvPath).text()
-        dotenv = this.parseDotenv(content)
-      }
-
+      const inheritedEnv = Object.fromEntries(
+        Object.entries(process.env).filter((item): item is [string, string] => item[1] !== undefined),
+      )
       const proc = Bun.spawn(['sh', '-c', entry.command], {
         cwd: entry.cwd,
+        detached: process.platform !== 'win32',
         env: {
+          ...inheritedEnv,
+          ...entry.env,
           FORCE_COLOR: '1',
           TERM: 'xterm-256color',
-          ...dotenv,
-          ...entry.env,
-          ...process.env as Record<string, string>,
         },
         stdout: 'pipe',
         stderr: 'pipe',
@@ -230,31 +229,36 @@ export class ServeManager {
 
     this.processes = procs.map(p => p.proc)
 
-    // Set up signal handlers
-    const cleanup = async () => {
-      if (this.interrupted) return
-      this.interrupted = true
-      if (process.stdout.isTTY) process.stdout.write(SHOW_CURSOR)
-      await this.shutdownAll(procs.map(p => p.proc))
-      process.exit(0)
+    const exitPromises = procs.map(({ proc, entry }) => proc.exited.then(code => {
+        writeOutputLine(`${colorPrefix(entry.name, entry.color)}\x1b[2mexited with code ${code}\x1b[0m`)
+        return code
+      }))
+
+    let resolveSignal!: (code: number) => void
+    let signalReceived = false
+    const signalExit = new Promise<number>(resolve => { resolveSignal = resolve })
+    const onSignal = () => {
+      signalReceived = true
+      resolveSignal(0)
     }
 
-    process.on('SIGINT', () => void cleanup())
-    process.on('SIGTERM', () => void cleanup())
-    process.on('SIGHUP', () => void cleanup())
+    process.once('SIGINT', onSignal)
+    process.once('SIGTERM', onSignal)
+    process.once('SIGHUP', onSignal)
 
-    // Wait for any process to exit or interrupt
-    const exitPromises = procs.map(({ proc, entry }) =>
-      proc.exited.then(code => {
-        writeOutputLine(`${colorPrefix(entry.name, entry.color)}\x1b[2mexited with code ${code}\x1b[0m`)
-        if (!this.interrupted) void cleanup()
-      }),
-    )
-
-    await Promise.race(exitPromises)
+    const firstCode = await Promise.race([...exitPromises, signalExit])
+    this.interrupted = true
+    if (process.stdout.isTTY) process.stdout.write(SHOW_CURSOR)
+    await this.shutdownAll(procs.map(p => p.proc))
     await Promise.all(exitPromises)
 
-    return true
+    process.off('SIGINT', onSignal)
+    process.off('SIGTERM', onSignal)
+    process.off('SIGHUP', onSignal)
+
+    if (signalReceived) process.exit(0)
+
+    return firstCode === 0
   }
 
   private async pipeOutput(stream: ReadableStream<Uint8Array> | null, name: string, color: number): Promise<void> {
@@ -289,7 +293,7 @@ export class ServeManager {
   private async shutdownAll(procs: Bun.Subprocess[]): Promise<void> {
     // Send SIGTERM to all
     for (const proc of procs) {
-      try { proc.kill(15) } catch {}
+      this.signalProcess(proc, 15)
     }
 
     // Give 5 seconds for graceful shutdown
@@ -299,7 +303,19 @@ export class ServeManager {
 
     // Force kill any still running
     for (const proc of procs) {
-      try { proc.kill(9) } catch {}
+      this.signalProcess(proc, 9)
+    }
+  }
+
+  private signalProcess(proc: Bun.Subprocess, signal: number): void {
+    try {
+      if (process.platform !== 'win32' && proc.pid) {
+        process.kill(-proc.pid, signal)
+      } else {
+        proc.kill(signal)
+      }
+    } catch {
+      // The process or process group has already exited.
     }
   }
 

--- a/src/types/capability.ts
+++ b/src/types/capability.ts
@@ -1,17 +1,20 @@
 import type { Command } from '@oclif/core'
 import type { Step, StepResolver } from './step.js'
 import type { RawCommand } from './config.js'
+import type { RawServeProcess } from './config.js'
 
 export const COMMAND_PROVIDER = 'CommandProvider'
 export const CONFIG_PROVIDER = 'ConfigProvider'
 export const ENV_PROVIDER = 'EnvProvider'
 export const PATH_PROVIDER = 'PathProvider'
+export const SERVE_PROVIDER = 'ServeProvider'
 
 export type CapabilityKey =
   | typeof COMMAND_PROVIDER
   | typeof CONFIG_PROVIDER
   | typeof ENV_PROVIDER
   | typeof PATH_PROVIDER
+  | typeof SERVE_PROVIDER
 
 export interface Capability {}
 
@@ -32,4 +35,8 @@ export interface EnvProvider extends Capability {
 
 export interface PathProvider extends Capability {
   paths(): string[]
+}
+
+export interface ServeProvider extends Capability {
+  processes(): Record<string, RawServeProcess>
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,51 +1,69 @@
-export type PromptArgs = {
-  prompt: string
-  label?: string
-  placeholder?: string
-  default?: string
-  required?: boolean
-  hint?: string
-  type?: 'password' | 'text'
-}
-
-export type RawEnvValue = string | number | boolean | PromptArgs
-
-export type RawCommand = {
-  desc?: string
-  run: string | string[]
-  signature?: string
-}
-
-export type RawServeProcess =
-  | string
-  | {
-      run: string
-      env?: string | false
-      cwd?: string
-    }
-
-export type RawServeGroup = Record<string, RawServeProcess>
-
-export type RawServe = RawServeProcess | RawServeGroup
+import { z } from 'zod'
 
 export type RawScript = {
-  desc?: string
-  name?: string
+  desc?: string | undefined
+  name?: string | undefined
   run: string | string[]
-  cwd?: string
-  'met?'?: string
+  cwd?: string | undefined
+  'met?'?: string | undefined
 }
 
 export type RawStep = Record<string, unknown> | RawScript
 
-export type RawConfig = {
-  name?: string
-  up?: RawStep[]
-  steps?: RawStep[]
-  commands?: Record<string, RawCommand>
-  serve?: Record<string, RawServe> | string
-  groups?: Record<string, string[]>
-  sites?: Record<string, string>
-  env?: Record<string, RawEnvValue>
-  projects?: string[]
-}
+const promptArgsSchema = z.object({
+  prompt: z.string(),
+  label: z.string().optional(),
+  placeholder: z.string().optional(),
+  default: z.string().optional(),
+  required: z.boolean().optional(),
+  hint: z.string().optional(),
+  type: z.enum(['password', 'text']).optional(),
+})
+
+const rawServeProcessSchema = z.union([
+  z.string(),
+  z.object({
+    run: z.string(),
+    env: z.union([z.string(), z.literal(false)]).optional(),
+    cwd: z.string().optional(),
+  }),
+])
+
+const rawRuntimeSchema = z.object({
+  type: z.literal('php').optional(),
+  version: z.string().optional(),
+  provider: z.enum(['auto', 'native', 'spc']).optional(),
+  server: z.literal('fpm').optional(),
+  extensions: z.array(z.string().min(1).regex(/^[A-Za-z0-9_]+$/)).optional(),
+})
+
+export const rawConfigSchema = z.object({
+  name: z.string().optional(),
+  type: z.string().optional(),
+  up: z.array(z.record(z.string(), z.unknown())).optional(),
+  steps: z.array(z.record(z.string(), z.unknown())).optional(),
+  commands: z.record(z.string(), z.object({
+    desc: z.string().optional(),
+    run: z.union([z.string(), z.array(z.string())]),
+    cwd: z.string().optional(),
+    signature: z.string().optional(),
+  })).optional(),
+  serve: z.union([z.string(), z.record(z.string(), z.union([
+    rawServeProcessSchema,
+    z.record(z.string(), rawServeProcessSchema),
+  ]))]).optional(),
+  groups: z.record(z.string(), z.array(z.string())).optional(),
+  sites: z.record(z.string(), z.string()).optional(),
+  env: z.record(z.string(), z.union([z.string(), z.number(), z.boolean(), promptArgsSchema])).optional(),
+  projects: z.array(z.string()).optional(),
+  runtimes: z.record(z.string(), rawRuntimeSchema).optional(),
+}).passthrough()
+
+export type PromptArgs = z.infer<typeof promptArgsSchema>
+export type RawEnvValue = string | number | boolean | PromptArgs
+export type RawServeProcess = z.infer<typeof rawServeProcessSchema>
+export type RawServeGroup = Record<string, RawServeProcess>
+export type RawServe = RawServeProcess | RawServeGroup
+export type RawRuntime = z.infer<typeof rawRuntimeSchema>
+export type RawConfig = z.infer<typeof rawConfigSchema>
+export type RawCommand = NonNullable<RawConfig['commands']>[string]

--- a/tests/caddy-project-sites.test.ts
+++ b/tests/caddy-project-sites.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+import { existsSync, mkdtempSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { CaddyStep } from '../src/plugins/caddy/steps/caddy-step.js'
+import { caddyProjectSitesDir, caddySiteFilename } from '../src/plugins/caddy/caddy-layout.js'
+import { Runner } from '../src/execution/runner.js'
+import { Config } from '../src/config/config.js'
+import { Repository } from '../src/execution/repository.js'
+import type { IOInterface } from '../src/types/io.js'
+
+const silentIO: IOInterface = {
+  writeln: () => {}, write: () => {}, info: () => {}, error: () => {}, dev: () => {},
+  stepStart: () => {}, stepEnd: () => {},
+  text: async () => '', password: async () => '',
+}
+
+function runnerFor(cwd: string): Runner {
+  return new Runner(new Config(cwd, {}), silentIO, new Repository())
+}
+
+describe('project-scoped Caddy sites', () => {
+  test('uses separate stable directories for separate projects', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-caddy-projects-'))
+    expect(caddyProjectSitesDir(root, '/work/alpha'))
+      .not.toBe(caddyProjectSitesDir(root, '/other/alpha'))
+  })
+
+  test('removes only stale configs owned by the current project', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-caddy-projects-'))
+    const alphaDir = caddyProjectSitesDir(root, '/work/alpha')
+    const betaDir = caddyProjectSitesDir(root, '/work/beta')
+
+    await new CaddyStep({ sites: ['old.alpha.test', 'keep.alpha.test'] }, alphaDir)
+      .run(runnerFor('/work/alpha'))
+    await new CaddyStep({ sites: ['beta.test'] }, betaDir)
+      .run(runnerFor('/work/beta'))
+    await new CaddyStep({ sites: ['keep.alpha.test'] }, alphaDir)
+      .run(runnerFor('/work/alpha'))
+
+    expect(existsSync(join(alphaDir, caddySiteFilename('old.alpha.test')))).toBeFalse()
+    expect(readdirSync(alphaDir)).toEqual([caddySiteFilename('keep.alpha.test')])
+    expect(readdirSync(betaDir)).toEqual([caddySiteFilename('beta.test')])
+  })
+
+  test('deploys only after all site configuration has been written', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-caddy-deploy-order-'))
+    const sitesDir = caddyProjectSitesDir(root, '/work/alpha')
+    const siteFile = join(sitesDir, caddySiteFilename('alpha.test'))
+    let deployed = false
+
+    const step = new CaddyStep({ sites: ['alpha.test'] }, sitesDir, async () => {
+      expect(existsSync(siteFile)).toBeTrue()
+      deployed = true
+      return true
+    })
+
+    expect(await step.run(runnerFor('/work/alpha'))).toBeTrue()
+    expect(deployed).toBeTrue()
+  })
+})

--- a/tests/caddy-runtime.test.ts
+++ b/tests/caddy-runtime.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from 'bun:test'
+import { CaddyRuntime } from '../src/plugins/caddy/caddy-runtime.js'
+
+describe('CaddyRuntime', () => {
+  test('runs Caddy as the user on Linux after a one-time bootstrap', () => {
+    const runtime = new CaddyRuntime('linux', '/usr/bin/caddy', 'sudo')
+    expect(runtime.reloadCommand('/home/user/.dev/caddy/Caddyfile'))
+      .toEqual([
+        '/usr/bin/caddy', 'reload', '--config', '/home/user/.dev/caddy/Caddyfile',
+        '--address', '127.0.0.1:2019', '--force',
+      ])
+    expect(runtime.linuxBootstrapCommands()).toEqual([
+      ['sudo', 'systemctl', 'disable', '--now', 'caddy'],
+      ['sudo', 'setcap', 'cap_net_bind_service=+ep', '/usr/bin/caddy'],
+    ])
+    expect(runtime.caCertificateSource('/home/user', '/home/user/.local/share'))
+      .toBe('/home/user/.local/share/caddy/pki/authorities/local/root.crt')
+    expect(runtime.linuxUserStartCommands()).toEqual([
+      ['systemctl', '--user', 'daemon-reload'],
+      ['systemctl', '--user', 'enable', '--now', 'dev-caddy.service'],
+    ])
+  })
+
+  test('uses high ports behind a macOS loopback redirect', () => {
+    const runtime = new CaddyRuntime('darwin', '/opt/homebrew/bin/caddy', 'sudo')
+    expect(runtime.httpPort()).toBe(8080)
+    expect(runtime.httpsPort()).toBe(8443)
+    expect(runtime.darwinBootstrapCommands('/Users/dev/.dev/caddy/pf.conf')).toEqual([
+      ['sudo', 'pfctl', '-a', 'com.apple/dev.caddy', '-f', '/Users/dev/.dev/caddy/pf.conf'],
+      ['sudo', 'pfctl', '-E'],
+    ])
+    expect(runtime.trustCommand()).toEqual([
+      '/opt/homebrew/bin/caddy', 'trust', '--address', '127.0.0.1:2019',
+    ])
+  })
+
+  test('supports an explicit privilege-free port configuration', () => {
+    const runtime = new CaddyRuntime('linux', '/usr/bin/caddy', 'sudo', {
+      DEV_CADDY_HTTP_PORT: '18080',
+      DEV_CADDY_HTTPS_PORT: '18443',
+      DEV_CADDY_ADMIN_PORT: '12019',
+    })
+    expect(runtime.httpPort()).toBe(18080)
+    expect(runtime.httpsPort()).toBe(18443)
+    expect(runtime.adminPort()).toBe(12019)
+    expect(runtime.trustCommand()).toEqual([
+      '/usr/bin/caddy', 'trust', '--address', '127.0.0.1:12019',
+    ])
+    expect(runtime.usesPrivilegedPorts()).toBeFalse()
+    expect(runtime.hasLowPortAccess()).toBeTrue()
+  })
+})

--- a/tests/caddy-site-step.test.ts
+++ b/tests/caddy-site-step.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, readdirSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { CaddySiteStep } from '../src/plugins/caddy/steps/caddy-site-step.js'
+import { Runner } from '../src/execution/runner.js'
+import { Config } from '../src/config/config.js'
+import { Repository } from '../src/execution/repository.js'
+import type { IOInterface } from '../src/types/io.js'
+
+const silentIO: IOInterface = {
+  writeln: () => {}, write: () => {}, info: () => {}, error: () => {}, dev: () => {},
+  stepStart: () => {}, stepEnd: () => {},
+  text: async () => '', password: async () => '',
+}
+
+function configAt(dir: string): string {
+  const files = readdirSync(dir).filter(file => file.endsWith('.conf'))
+  expect(files).toHaveLength(1)
+  return readFileSync(join(dir, files[0]!), 'utf8')
+}
+
+function runnerFor(cwd: string): Runner {
+  return new Runner(new Config(cwd, {}), silentIO, new Repository())
+}
+
+describe('CaddySiteStep', () => {
+  test('uses internal HTTPS by default and supports wildcard hosts', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({ host: '*.example.test', proxy: 'http://127.0.0.1:9401' }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    const config = configAt(dir)
+    expect(config).toContain('https://*.example.test')
+    expect(config).toContain('tls internal')
+  })
+
+  test('allows automatic TLS as an explicit opt-in', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: 'public.example.com',
+      proxy: 'http://127.0.0.1:9401',
+      tls: 'automatic',
+    }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    expect(configAt(dir)).not.toContain('tls internal')
+  })
+
+  test('honors secure false', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({ host: 'plain.example.test', secure: false }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    expect(configAt(dir))
+      .toContain('http://plain.example.test')
+  })
+
+  test('renders Okra proxy behavior declaratively', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: '*.ciroue.test',
+      proxy: 'http://127.0.0.1:8787',
+      max_request_body: '26MB',
+      flush_interval: '-1',
+      request_headers: { 'X-NginX-Proxy': 'true' },
+      response_headers: {
+        'Cross-Origin-Resource-Policy': 'cross-origin',
+        'Cross-Origin-Embedder-Policy': 'credentialless',
+        'Access-Control-Allow-Origin': '*',
+      },
+    }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    const config = configAt(dir)
+    expect(config).toContain('max_size 26MB')
+    expect(config).toContain('tls internal')
+    expect(config).toContain('?Cross-Origin-Resource-Policy "cross-origin"')
+    expect(config).toContain('header_up X-NginX-Proxy "true"')
+    expect(config).toContain('flush_interval -1')
+  })
+
+  test('renders path routes, URI stripping, and a fallback proxy', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: 'app.example.test',
+      proxy: 'http://127.0.0.1:9500',
+      routes: [
+        {
+          path: '/socket*',
+          strip_prefix: '/socket',
+          proxy: 'http://127.0.0.1:6001',
+        },
+        {
+          path: '/build/assets*',
+          proxy: 'http://127.0.0.1:9500',
+          response_headers: { 'Cross-Origin-Opener-Policy': 'same-origin' },
+        },
+      ],
+    }, dir)
+
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    const config = configAt(dir)
+    expect(config).toContain('handle /socket*')
+    expect(config).toContain('uri strip_prefix /socket')
+    expect(config).toContain('reverse_proxy http://127.0.0.1:6001')
+    expect(config).toContain('handle /build/assets*')
+    expect(config).toContain('?Cross-Origin-Opener-Policy "same-origin"')
+    expect(config).toContain('handle {\n\t\treverse_proxy http://127.0.0.1:9500')
+  })
+
+  test('renders a project-relative PHP-FPM site', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: 'php.example.test',
+      root: 'public',
+      php_fastcgi: '127.0.0.1:9074',
+    }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    const config = configAt(dir)
+    expect(config).toContain('root * "/project/public"')
+    expect(config).toContain('php_fastcgi "127.0.0.1:9074"')
+    expect(config).toContain('file_server')
+  })
+
+  test('quotes document roots containing spaces', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: 'spaces.example.test',
+      root: 'public files',
+      php_fastcgi: '127.0.0.1:9074',
+    }, dir)
+    expect(await step.run(runnerFor('/project root'))).toBeTrue()
+    expect(configAt(dir)).toContain('root * "/project root/public files"')
+  })
+
+  test('renders a static-file route without a proxy', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'dev-caddy-site-'))
+    const step = new CaddySiteStep({
+      host: 'php.example.test',
+      root: 'public',
+      php_fastcgi: '127.0.0.1:9074',
+      routes: [{
+        path: '/build/assets*',
+        file_server: true,
+        response_headers: { 'Cross-Origin-Resource-Policy': 'cross-origin' },
+      }],
+    }, dir)
+    expect(await step.run(runnerFor('/project'))).toBeTrue()
+    const config = configAt(dir)
+    expect(config).toContain('handle /build/assets*')
+    expect(config).toContain('?Cross-Origin-Resource-Policy "cross-origin"')
+    expect(config).toContain('\t\tfile_server')
+  })
+})

--- a/tests/dns-config.test.ts
+++ b/tests/dns-config.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from 'bun:test'
+import { DnsConfig } from '../src/plugins/core/config/dns-config.js'
+
+describe('DnsConfig', () => {
+  test('derives Docker default bridge interface name', () => {
+    const config = new DnsConfig({
+      server: '172.29.0.53',
+      domains: ['ciroue.test', 'phpsandbox.test'],
+      docker_network: 'okra-dev',
+    })
+    expect(config.interface(() => ({
+      id: '1234567890abcdef',
+      bridge: '',
+    }))).toBe('br-1234567890ab')
+  })
+
+  test('uses an explicitly named Docker bridge', () => {
+    const config = new DnsConfig({
+      server: '172.29.0.53',
+      domains: ['ciroue.test'],
+      docker_network: 'okra-dev',
+    })
+    expect(config.interface(() => ({ id: 'ignored', bridge: 'okra0' }))).toBe('okra0')
+  })
+
+  test('treats Docker no-value bridge output as the default bridge', () => {
+    const config = new DnsConfig({
+      server: '172.29.0.53',
+      domains: ['ciroue.test'],
+      docker_network: 'okra-dev',
+    })
+    expect(config.interface(() => ({ id: 'abcdef1234567890', bridge: '' })))
+      .toBe('br-abcdef123456')
+  })
+
+  test('builds split-DNS commands for systemd-resolved', () => {
+    const config = new DnsConfig({
+      server: '172.29.0.53',
+      domains: ['ciroue.test', 'phpsandbox.test'],
+      interface: 'okra0',
+    })
+    expect(config.configureCommands('okra0', 'sudo')).toEqual([
+      ['sudo', 'resolvectl', 'dns', 'okra0', '172.29.0.53'],
+      ['sudo', 'resolvectl', 'domain', 'okra0', '~ciroue.test', '~phpsandbox.test'],
+      ['sudo', 'resolvectl', 'default-route', 'okra0', 'no'],
+    ])
+  })
+})

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'bun:test'
+import { Env } from '../src/config/env.js'
+import { Config } from '../src/config/config.js'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { commandWorkingDirectory } from '../src/config/command.js'
+import { EnvSubstituteStep } from '../src/plugins/core/steps/env-substitute-step.js'
+import { Runner } from '../src/execution/runner.js'
+import { Repository } from '../src/execution/repository.js'
+import type { IOInterface } from '../src/types/io.js'
+
+const silentIO: IOInterface = {
+  writeln: () => {}, write: () => {}, info: () => {}, error: () => {}, dev: () => {},
+  stepStart: () => {}, stepEnd: () => {},
+  text: async () => '', password: async () => '',
+}
+
+describe('Env', () => {
+  test('uses a supplied process value instead of prompting or persisting it', async () => {
+    const env = new Env({
+      TOKEN: {
+        prompt: 'Token?',
+        required: true,
+      },
+    }, { TOKEN: 'temporary-token' })
+
+    const [resolved, prompted] = await env.resolve()
+
+    expect(resolved.get('TOKEN')).toBe('temporary-token')
+    expect(prompted).toEqual({})
+    expect(env.wasPrompted()).toBeFalse()
+  })
+})
+
+describe('command configuration', () => {
+  test('preserves a project-relative working directory', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-command-cwd-'))
+    writeFileSync(join(root, 'dev.yml'), 'commands:\n  inspect:\n    cwd: go\n    run: pwd\n')
+
+    const config = Config.read(root)
+    const command = config.commands()['inspect']
+    expect(command?.cwd).toBe('go')
+    expect(command && commandWorkingDirectory(config, command)).toBe(join(root, 'go'))
+  })
+})
+
+describe('environment file updates', () => {
+  test('uses single quotes and groups values owned by DEV', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-env-file-'))
+    writeFileSync(join(root, 'dev.yml'), [
+      'env:',
+      '  APP_NAME: Okra',
+      '  DEV_ONLY: grouped',
+      '',
+    ].join('\n'))
+    writeFileSync(join(root, '.env.example'), 'APP_NAME=Example\nSAMPLE_ONLY=sample\n')
+    writeFileSync(join(root, '.env'), 'APP_NAME="Old"\n')
+    const config = Config.read(root)
+    const runner = new Runner(config, silentIO, new Repository())
+
+    expect(await new EnvSubstituteStep(config).run(runner)).toBeTrue()
+    expect(readFileSync(join(root, '.env'), 'utf8')).toBe([
+      "APP_NAME='Okra'",
+      "SAMPLE_ONLY='sample'",
+      '',
+      '# DEV managed environment — generated from dev.yml',
+      "DEV_ONLY='grouped'",
+      '# End DEV managed environment',
+      '',
+    ].join('\n'))
+  })
+})

--- a/tests/package-manager.test.ts
+++ b/tests/package-manager.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import { PackageManager } from '../src/plugins/core/config/package-manager.js'
+
+describe('PackageManager', () => {
+  test('detects pacman for Omarchy', () => {
+    const manager = PackageManager.detect('linux', command => command === 'pacman', '/etc/os-release')
+    expect(manager.name).toBe('pacman')
+  })
+
+  test('maps portable package names for pacman', () => {
+    const manager = new PackageManager('pacman', 'sudo')
+    expect(manager.resolve(['openssl', 'aws-cli', 'redis', 'go', 'caddy']))
+      .toEqual(['openssl', 'aws-cli', 'valkey', 'go', 'caddy'])
+  })
+
+  test('maps native PHP and Composer across supported managers', () => {
+    expect(new PackageManager('pacman', 'sudo').resolve(['php', 'php-fpm', 'composer']))
+      .toEqual(['php', 'php-fpm', 'composer'])
+    expect(new PackageManager('apt', 'sudo').resolve(['php', 'php-fpm', 'composer']))
+      .toEqual(['php-cli', 'php-fpm', 'composer'])
+    expect(new PackageManager('brew', 'sudo').resolve(['php', 'php-fpm', 'composer']))
+      .toEqual(['php', 'composer'])
+  })
+
+  test('uses Homebrew Node for both node and npm without duplicates', () => {
+    const manager = new PackageManager('brew', 'sudo')
+    expect(manager.resolve(['node', 'npm'])).toEqual(['node'])
+  })
+
+  test('supports per-manager overrides', () => {
+    const manager = new PackageManager('pacman', 'sudo')
+    expect(manager.resolve([{ name: 'custom-tool', pacman: 'custom-tool-bin' }]))
+      .toEqual(['custom-tool-bin'])
+  })
+
+  test('refuses unsupported native mappings', () => {
+    const manager = new PackageManager('pacman', 'sudo')
+    expect(() => manager.resolve(['s5cmd'])).toThrow("Package 's5cmd' has no pacman package mapping")
+  })
+
+  test('builds non-upgrading pacman installation command', () => {
+    const manager = new PackageManager('pacman', 'sudo')
+    expect(manager.installCommand(['go', 'caddy']))
+      .toEqual(['sudo', 'pacman', '-S', '--needed', '--noconfirm', 'go', 'caddy'])
+  })
+})

--- a/tests/php-runtime.test.ts
+++ b/tests/php-runtime.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+import { PhpRuntime } from '../src/plugins/php-runtime/php-runtime.js'
+import { Config } from '../src/config/config.js'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+describe('PhpRuntime', () => {
+  test('supports exact minor and bounded version requirements', () => {
+    expect(PhpRuntime.satisfies('8.2.33', '8.2')).toBeTrue()
+    expect(PhpRuntime.satisfies('8.3.0', '8.2')).toBeFalse()
+    expect(PhpRuntime.satisfies('8.5.9', '>=8.2 <8.6')).toBeTrue()
+    expect(PhpRuntime.satisfies('8.6.0', '>=8.2 <8.6')).toBeFalse()
+    expect(PhpRuntime.satisfies('8.4.2', '^8.2')).toBeTrue()
+    expect(PhpRuntime.satisfies('9.0.0', '^8.2')).toBeFalse()
+  })
+
+  test('uses a project-scoped Unix socket endpoint', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-php-runtime-'))
+    writeFileSync(join(root, 'dev.yml'), 'runtimes:\n  php:\n    version: "8.5"\n')
+    const config = Config.read(root)
+    expect(PhpRuntime.endpoint(config, 'php'))
+      .toBe(`unix/${root}/.dev/runtimes/php/php-fpm.sock`)
+  })
+
+  test('resolves an SPC runtime into an extension-specific cache', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-php-spc-'))
+    writeFileSync(join(root, 'dev.yml'), [
+      'runtimes:',
+      '  php:',
+      '    version: "8.4"',
+      '    provider: spc',
+      '    extensions: [curl, pdo_mysql]',
+      '',
+    ].join('\n'))
+    const runtime = PhpRuntime.resolve(Config.read(root), 'php')
+    expect(runtime.provider).toBe('spc')
+    expect(runtime.version).toBe('8.4')
+    expect(runtime.binDir).toContain('/runtimes/php/8.4/spc/')
+    expect(runtime.phpBinary).toBe(join(runtime.binDir, 'php'))
+    expect(runtime.fpmBinary).toBe(join(runtime.binDir, 'php-fpm'))
+  })
+
+  test('uses separate SPC artifacts for distinct extension sets', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-php-spc-cache-'))
+    const configPath = join(root, 'dev.yml')
+    writeFileSync(configPath, 'runtimes:\n  php:\n    version: "8.4"\n    provider: spc\n    extensions: [curl]\n')
+    const curlRuntime = PhpRuntime.resolve(Config.read(root), 'php')
+    writeFileSync(configPath, 'runtimes:\n  php:\n    version: "8.4"\n    provider: spc\n    extensions: [curl, zip]\n')
+    const zipRuntime = PhpRuntime.resolve(Config.read(root), 'php')
+    expect(curlRuntime.root).not.toBe(zipRuntime.root)
+  })
+
+})

--- a/tests/recovery-safety.test.ts
+++ b/tests/recovery-safety.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdirSync, mkdtempSync, symlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { mysqlConfigSchema } from '../src/plugins/core/config/mysql-config.js'
+import { isRepairableManagedCheckout } from '../src/plugins/core/steps/clone-step.js'
+
+describe('managed recovery safety', () => {
+  test('repairs only real directories below the DEV dependency root', () => {
+    const root = mkdtempSync(join(tmpdir(), 'dev-recovery-'))
+    const checkout = join(root, 'src/github.com/example/project')
+    const outside = join(root, 'outside')
+    const link = join(root, 'src/github.com/example/link')
+    mkdirSync(checkout, { recursive: true })
+    mkdirSync(outside)
+    symlinkSync(outside, link)
+
+    expect(isRepairableManagedCheckout(root, checkout)).toBeTrue()
+    expect(isRepairableManagedCheckout(root, outside)).toBeFalse()
+    expect(isRepairableManagedCheckout(root, link)).toBeFalse()
+  })
+
+  test('accepts safe database names and rejects SQL fragments', () => {
+    expect(mysqlConfigSchema.safeParse({ databases: ['app_dev', 'app-test'] }).success).toBeTrue()
+    expect(mysqlConfigSchema.safeParse({ databases: 'app`; DROP DATABASE mysql; --' }).success).toBeFalse()
+  })
+})

--- a/tests/service-manager.test.ts
+++ b/tests/service-manager.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from 'bun:test'
+import { ServiceManager } from '../src/plugins/core/config/service-manager.js'
+
+describe('ServiceManager', () => {
+  test('maps Redis to Valkey on Pacman systems', () => {
+    const manager = new ServiceManager('pacman', 'sudo')
+    expect(manager.resolve('redis')).toBe('valkey')
+    expect(manager.startCommand('valkey')).toEqual([
+      'sudo', 'systemctl', 'enable', '--now', 'valkey',
+    ])
+  })
+
+  test('uses brew services only when Brew was selected', () => {
+    const manager = new ServiceManager('brew', 'sudo')
+    expect(manager.resolve('redis')).toBe('redis')
+    expect(manager.startCommand('redis')).toEqual(['brew', 'services', 'start', 'redis'])
+  })
+
+  test('allows an explicit native unit override', () => {
+    const manager = new ServiceManager('apt', 'sudo')
+    expect(manager.resolve({ name: 'redis', unit: 'custom-redis' })).toBe('custom-redis')
+  })
+})

--- a/tests/shadowenv.test.ts
+++ b/tests/shadowenv.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test'
+import { shadowenvAsset } from '../src/plugins/core/steps/shadowenv/ensure-shadowenv-step.js'
+
+describe('Shadowenv installer', () => {
+  test('selects the official Linux x86_64 release asset', () => {
+    expect(shadowenvAsset('linux', 'x64')).toBe('shadowenv-x86_64-unknown-linux-gnu')
+  })
+
+  test('selects the official macOS arm64 release asset', () => {
+    expect(shadowenvAsset('darwin', 'arm64')).toBe('shadowenv-aarch64-apple-darwin')
+  })
+})


### PR DESCRIPTION
## Summary

- add portable package, service, and split-DNS abstractions across Homebrew, Apt, and Pacman environments
- add project-isolated PHP runtimes with native and static-php-cli providers, extension-aware artifacts, PHP-FPM Unix sockets, and runtime-aware serve environments
- replace Valet-specific setup requirements with DEV-owned Caddy lifecycle management, project-scoped site configs, internal TLS defaults, wildcard routing, and Caddy commands
- harden dependency cloning, MySQL readiness/database creation, Shadowenv installation and refresh, command working directories, and process supervision
- group DEV-managed dotenv values with single-quoted formatting and stale-value cleanup
- migrate DEV itself to Bun-only setup and remove obsolete PHP setup steps

## Validation

- `dev typecheck`
- `dev test` (39 passing)
- `bun run build`
- `git diff --check`
- exercised Caddy, PHP-FPM/SPC, MySQL, dependency setup, and multi-process serving against Okra and Core on Omarchy Linux
